### PR TITLE
Add .NET Framework 4.8 support

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,19 +17,33 @@ jobs:
       - name: ✨ Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: | 
+            8.0.x
+            4.8
 
       - name: 🛠️ Setup NuGet
         uses: nuget/setup-nuget@v1
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
 
+      - name: 🚀 Build and Pack QuickTickLib (.NET 8.0)
+        run: |
+          dotnet restore QuickTickLib/QuickTickLib.csproj --framework net8.0
+          dotnet build QuickTickLib/QuickTickLib.csproj --configuration Release --framework net8.0
+          dotnet pack QuickTickLib/QuickTickLib.csproj --configuration Release --framework net8.0
+        if: success()
+
+      - name: 🚀 Build and Pack QuickTickLib (.NET Framework 4.8)
+        run: |
+          dotnet restore QuickTickLib/QuickTickLib.csproj --framework net48
+          dotnet build QuickTickLib/QuickTickLib.csproj --configuration Release --framework net48
+          dotnet pack QuickTickLib/QuickTickLib.csproj --configuration Release --framework net48
+        if: success()
+
       - name: 🚀 Publish QuickTickLib
         run: |
-          dotnet restore QuickTickLib/QuickTickLib.csproj
-          dotnet build QuickTickLib/QuickTickLib.csproj --configuration Release
-          dotnet pack QuickTickLib/QuickTickLib.csproj --configuration Release
-          nuget push "QuickTickLib\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+          nuget push "QuickTickLib/bin/Release/*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+        if: success()
 
       - name: 💾 Store Packages
         uses: actions/upload-artifact@v4

--- a/QuickTickLib/QuickTickLib.csproj
+++ b/QuickTickLib/QuickTickLib.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    
     <Authors>Uight</Authors>
     <Description>HighPrecision Timer, Sleep and Delay functions in .net8.0</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,6 +20,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/QuickTickLib/QuickTickTimer.cs
+++ b/QuickTickLib/QuickTickTimer.cs
@@ -4,13 +4,15 @@ public sealed class QuickTickTimer : IQuickTickTimer
 {
     private readonly IQuickTickTimer timer;
 
-    public QuickTickTimer(double interval)
+    public QuickTickTimer(double interval, QuickTickElapsedEventHandler? elapsed = null, bool throwIfFallback = false)
     {
         var isQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
+        if (!isQuickTickSupported && throwIfFallback) throw new PlatformNotSupportedException();
         timer = isQuickTickSupported ? new QuickTickTimerImplementation(interval) : new QuickTickTimerFallback(interval);
+        Elapsed += elapsed;
     }
 
-    public QuickTickTimer(TimeSpan interval) : this(interval.TotalMilliseconds) { }
+    public QuickTickTimer(TimeSpan interval, QuickTickElapsedEventHandler? elapsed = null, bool throwIfFallback = false) : this(interval.TotalMilliseconds, elapsed, throwIfFallback) { }
 
     public double Interval
     {

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -27,14 +27,13 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
                 throw new ArgumentOutOfRangeException("Interval must be between 1 and int.MaxValue");
             }
 
-            double roundedInterval = Math.Ceiling(value);
-            if (roundedInterval > int.MaxValue || roundedInterval <= 0)
+            if (value > int.MaxValue || value <= 0)
             {
                 throw new ArgumentOutOfRangeException("Interval must be between 1 and int.MaxValue");
             }
 
-            intervalMs = roundedInterval;
-            intervalTicks = TimeSpan.FromMilliseconds(intervalMs).Ticks;
+            intervalMs = value;
+            intervalTicks = (long)(intervalMs * TimeSpan.TicksPerMillisecond);
         }
     }
 

--- a/QuickTickLib/Win32Interop.cs
+++ b/QuickTickLib/Win32Interop.cs
@@ -7,6 +7,7 @@ internal partial class Win32Interop
     private const string KernelDll = "kernel32.dll";
     private const string NtDll = "ntdll.dll";
 
+#if NET8_0
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool CloseHandle(
@@ -21,29 +22,12 @@ internal partial class Win32Interop
         uint NumberOfConcurrentThreads // Number of threads that can be used for completion packages. 0 to allow the number of processors in the system
     );
 
-    [Flags]
-    public enum TimerAccessMask : uint
-    {
-        DELETE = 0x00010000,
-        READ_CONTROL = 0x00020000,
-        SYNCHRONIZE = 0x00100000,
-        WRITE_DAC = 0x00040000,
-        WRITE_OWNER = 0x00080000,
-        TIMER_ALL_ACCESS = 0x1F0003,
-        TIMER_MODIFY_STATE = 0x0002,
-        TIMER_QUERY_STATE = 0x0001, //Reserved for future // Is needed for NtCreateWaitCompletionPacket
-    }
-
     [LibraryImport(NtDll, SetLastError = true)]
     public static partial int NtCreateWaitCompletionPacket(
         out IntPtr WaitCompletionPacketHandle, // A pointer to a variable that receives the wait completion packet handle
         uint DesiredAccess, // Access mask for the wait completion packet
         IntPtr ObjectAttributes // Optional pointer to  PROJECT_ATTRIBUTES // Not needed here
     );
-
-    public const uint CreateWaitableTimerFlag_NONE = 0x00000000;
-    public const uint CreateWaitableTimerFlag_MANUAL_RESET = 0x00000001;
-    public const uint CreateWaitableTimerFlag_HIGH_RESOLUTION = 0x00000002;
 
     [LibraryImport(KernelDll, SetLastError = true)]
     public static partial IntPtr CreateWaitableTimerExW(
@@ -85,11 +69,11 @@ internal partial class Win32Interop
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool GetQueuedCompletionStatus(
-    IntPtr completionPort, // Handle to the I/O completion port
-    out uint lpNumberOfBytesTransferred, // Number of bytes transferred in the I/O completion operation.
-    out IntPtr lpCompletionKey, // Pointer to the completionKey
-    out IntPtr lpOverlapped, // Pointer to a OVERLAPPED structure that was specified when the completed I/O operation was started.
-    uint dwMilliseconds // Timeout for the wait operation, uint.MaxValue means Infinite
+        IntPtr completionPort, // Handle to the I/O completion port
+        out uint lpNumberOfBytesTransferred, // Number of bytes transferred in the I/O completion operation.
+        out IntPtr lpCompletionKey, // Pointer to the completionKey
+        out IntPtr lpOverlapped, // Pointer to a OVERLAPPED structure that was specified when the completed I/O operation was started.
+        uint dwMilliseconds // Timeout for the wait operation, uint.MaxValue means Infinite
     );
 
     [LibraryImport(KernelDll, SetLastError = true)]
@@ -106,6 +90,107 @@ internal partial class Win32Interop
         IntPtr WaitCompletionPacketHandle, // Handle to a wait completion package
         [MarshalAs(UnmanagedType.Bool)] bool RemoveSignaledPacket // Whether to attempt to cancel a packet from IO completion object queue.
     );
+#else
+  [DllImport(KernelDll, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CloseHandle(
+        IntPtr hObject // The handle to close
+    );
+
+    [DllImport(KernelDll, SetLastError = true)]
+    public static extern IntPtr CreateIoCompletionPort(
+        IntPtr FileHandle, // A file handle or INVALID_HANDLE_VALUE
+        IntPtr ExistingCompletionPort, // Handle for an open I/O completion port or null
+        IntPtr CompletionKey, // Optional CompletionKey for I/O completion packages
+        uint NumberOfConcurrentThreads // Number of threads for completion packages, 0 for system processor count
+    );
+
+    [DllImport(NtDll, SetLastError = true)]
+    public static extern int NtCreateWaitCompletionPacket(
+        out IntPtr WaitCompletionPacketHandle, // Receives the wait completion packet handle
+        uint DesiredAccess, // Access mask for the wait completion packet
+        IntPtr ObjectAttributes // Optional pointer to OBJECT_ATTRIBUTES
+    );
+
+    [DllImport(KernelDll, SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern IntPtr CreateWaitableTimerExW(
+        IntPtr lpTimerAttributes, // Optional pointer to a SECURITY_ATTRIBUTES structure
+        IntPtr lpTimerName, // Optional pointer to the name of the timer
+        uint dwFlags, // Flags for the timer
+        uint dwDesiredAccess // Access mask for the timer object
+    );
+
+    [DllImport(NtDll, SetLastError = true)]
+    public static extern int NtAssociateWaitCompletionPacket(
+        IntPtr WaitCompletionPacketHandle, // Handle to a wait completion packet
+        IntPtr IoCompletionHandle, // Handle to the I/O completion port
+        IntPtr TargetObjectHandle, // A handle to a waitable object (e.g., timer)
+        IntPtr KeyContext, // Optional key context
+        IntPtr ApcContext, // Optional APC context
+        int IoStatus, // Status for NtRemoveIoCompletion
+        IntPtr IoStatusInformation, // Status information for NtRemoveIoCompletion
+        [MarshalAs(UnmanagedType.Bool)] out bool AlreadySignaled // Indicates if the target object was already signaled
+    );
+
+    [DllImport(KernelDll, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetWaitableTimer(
+        IntPtr hTimer, // Pointer to the timer
+        ref long lpDueTime, // Due time (absolute or relative in 100ns steps)
+        int lPeriod, // Period for recurring timer, 0 for one-shot
+        IntPtr pfnCompletionRoutine, // Optional completion routine
+        IntPtr lpArgToCompletionRoutine, // Optional arguments for completion routine
+        [MarshalAs(UnmanagedType.Bool)] bool fResume // Energy-saving mode setting
+    );
+
+    [DllImport(KernelDll, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CancelWaitableTimer(
+        IntPtr hTimer // Handle of the timer to cancel
+    );
+
+    [DllImport(KernelDll, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetQueuedCompletionStatus(
+        IntPtr completionPort, // Handle to the I/O completion port
+        out uint lpNumberOfBytesTransferred, // Bytes transferred in I/O operation
+        out IntPtr lpCompletionKey, // Pointer to the completion key
+        out IntPtr lpOverlapped, // Pointer to OVERLAPPED structure
+        uint dwMilliseconds // Timeout for wait, uint.MaxValue for infinite
+    );
+
+    [DllImport(KernelDll, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool PostQueuedCompletionStatus(
+        IntPtr completionPort, // Handle to the I/O completion port
+        uint numberOfBytesTransferred, // Value for lpNumberOfBytesTransferred
+        IntPtr completionKey, // Value for lpCompletionKey
+        IntPtr lpOverlapped // Value for lpOverlapped
+    );
+
+    [DllImport(NtDll, SetLastError = true)]
+    public static extern int NtCancelWaitCompletionPacket(
+        IntPtr WaitCompletionPacketHandle, // Handle to a wait completion packet
+        [MarshalAs(UnmanagedType.Bool)] bool RemoveSignaledPacket // Whether to cancel a packet from the IO completion queue
+    );
+#endif
+
+    [Flags]
+    public enum TimerAccessMask : uint
+    {
+        DELETE = 0x00010000,
+        READ_CONTROL = 0x00020000,
+        SYNCHRONIZE = 0x00100000,
+        WRITE_DAC = 0x00040000,
+        WRITE_OWNER = 0x00080000,
+        TIMER_ALL_ACCESS = 0x1F0003,
+        TIMER_MODIFY_STATE = 0x0002,
+        TIMER_QUERY_STATE = 0x0001, //Reserved for future // Is needed for NtCreateWaitCompletionPacket
+    }
+
+    public const uint CreateWaitableTimerFlag_NONE = 0x00000000;
+    public const uint CreateWaitableTimerFlag_MANUAL_RESET = 0x00000001;
+    public const uint CreateWaitableTimerFlag_HIGH_RESOLUTION = 0x00000002;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct OVERLAPPED_ENTRY


### PR DESCRIPTION
- Add .NET Framework 4.8 support
- Allow for fractional millisecond intervals in the QuickTickTimer
- Improve the QuickTickTimer constructor to be able to trigger an exception if the fallback implementation is used.