### PR TITLE
Use safe handles were possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+*.idea
+
+# Claude
+*.claude

--- a/QuickTick.sln
+++ b/QuickTick.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35728.132
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickTestProjectNetFramework", "QuickTestProjectNetFramework\QuickTestProjectNetFramework.csproj", "{403A72CA-519F-E2D4-5CE9-F668ACDC2C0E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickTickTimingReportGenerator", "QuickTickTimingReportGenerator\QuickTickTimingReportGenerator.csproj", "{92D3CA21-9E4F-4BA2-81E6-5FE236D70D9E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuickTickTests", "QuickTickTests\QuickTickTests.csproj", "{F205E39B-6567-446B-ABFA-8DA18CC90ED3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{92D3CA21-9E4F-4BA2-81E6-5FE236D70D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92D3CA21-9E4F-4BA2-81E6-5FE236D70D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92D3CA21-9E4F-4BA2-81E6-5FE236D70D9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F205E39B-6567-446B-ABFA-8DA18CC90ED3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F205E39B-6567-446B-ABFA-8DA18CC90ED3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F205E39B-6567-446B-ABFA-8DA18CC90ED3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F205E39B-6567-446B-ABFA-8DA18CC90ED3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -154,7 +154,13 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
             running = false;
             cancellationTokenSource?.Cancel();
-            cancellationTokenSource?.Dispose();
+            cancellationTokenSource = null;
+            
+            if (Thread.CurrentThread != workerThread)
+            {
+                workerThread?.Join();
+            }
+            workerThread = null;
         }
     }
 

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -18,6 +18,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     private ThreadPriority threadPriority = ThreadPriority.Highest;
     private CancellationTokenSource? cancellationTokenSource;
     private Thread? workerThread;
+    private readonly object stateLock = new();
     private QuickTickElapsedEventHandler? elapsed;
 
     public double Interval
@@ -121,34 +122,40 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
     public void Start()
     {
-        if (running)
+        lock (stateLock)
         {
-            return;
+            if (running)
+            {
+                return;
+            }
+
+            running = true;
+            var cts = new CancellationTokenSource();
+
+            workerThread = new Thread(() => RunTimer(cts))
+            {
+                IsBackground = true,
+                Priority = Priority
+            };
+
+            cancellationTokenSource = cts;
+            workerThread.Start();
         }
-
-        running = true;
-        var cts = new CancellationTokenSource();
-
-        workerThread = new Thread(() => RunTimer(cts))
-        {
-            IsBackground = true,
-            Priority = Priority
-        };
-
-        cancellationTokenSource = cts;
-        workerThread.Start();
     }
 
     public void Stop()
     {
-        if (!running)
+        lock (stateLock)
         {
-            return;
-        }
+            if (!running)
+            {
+                return;
+            }
 
-        running = false;
-        cancellationTokenSource?.Cancel();
-        cancellationTokenSource?.Dispose();
+            running = false;
+            cancellationTokenSource?.Cancel();
+            cancellationTokenSource?.Dispose();
+        }
     }
 
     private void RunTimer(CancellationTokenSource localCancellationTokenSource)

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -224,17 +224,19 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
 
-            if (!localCancellationTokenSource.IsCancellationRequested)
-            {
-                var handler = elapsed;
-                handler?.Invoke(this, elapsedEventArgs);
-            }
-
             if (!autoReset)
             {
                 running = false;
                 stopWatch.Reset();
+                var handler = elapsed;
+                handler?.Invoke(this, elapsedEventArgs);
                 break;
+            }
+
+            if (!localCancellationTokenSource.IsCancellationRequested)
+            {
+                var handler = elapsed;
+                handler?.Invoke(this, elapsedEventArgs);
             }
         }
     }

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -151,6 +151,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
         running = false;
         cancellationTokenSource?.Cancel();
+        cancellationTokenSource?.Dispose();
     }
 
     private void RunTimer(CancellationTokenSource cancellationTokenSource)

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -12,8 +12,8 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     private volatile bool running;
     private volatile bool skipMissedIntervals;
     private volatile float intervalMs;
-    private volatile float sleepThreshold = 1.5f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensivly testing with the TimingReportGenerator
-    private volatile float yieldThreshold = 0.75f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensivly testing with the TimingReportGenerator
+    private volatile float sleepThreshold = 1.5f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensively testing with the TimingReportGenerator
+    private volatile float yieldThreshold = 0.75f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensively testing with the TimingReportGenerator
     private long intervalTicks;
     private ThreadPriority threadPriority = ThreadPriority.Highest;
     private CancellationTokenSource? cancellationTokenSource;
@@ -44,10 +44,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     public bool SkipMissedIntervals
     {
         get => skipMissedIntervals;
-        set
-        {
-            skipMissedIntervals = value;
-        }
+        set => skipMissedIntervals = value;
     }
 
     public ThreadPriority Priority
@@ -56,7 +53,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
         set
         {
             threadPriority = value;
-            if (workerThread != null)
+            if (workerThread is { IsAlive: true })
             {
                 workerThread.Priority = value;
             }
@@ -100,7 +97,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     /// Increasing this time can lead to better timing but increases CPU usage as the code will SpinWait instead.
     /// Must be at least 0.0 and at most the value of SleepThreshold. 
     /// Setting YieldThreshold equal to SleepThreshold disables yielding (goes directly to spin wait).
-    /// Setting YieldThreshold equal to 0.0 will basically disable spin waiting altough if no process is ready to run on this thread the behavior is almost the same.
+    /// Setting YieldThreshold equal to 0.0 will basically disable spin waiting although if no process is ready to run on this thread the behavior is almost the same.
     /// </summary>
     public double YieldThreshold
     {
@@ -154,7 +151,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
         cancellationTokenSource?.Dispose();
     }
 
-    private void RunTimer(CancellationTokenSource cancellationTokenSource)
+    private void RunTimer(CancellationTokenSource localCancellationTokenSource)
     {
         var stopWatch = new Stopwatch();
         stopWatch.Start();
@@ -162,7 +159,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
         var skippedIntervals = 0L;
         var lastFireTicks = 0L;
 
-        while (!cancellationTokenSource.IsCancellationRequested)
+        while (!localCancellationTokenSource.IsCancellationRequested)
         {      
             while (true)
             {                
@@ -185,7 +182,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
                     Thread.SpinWait(10);
                 }
 
-                if (cancellationTokenSource.IsCancellationRequested)
+                if (localCancellationTokenSource.IsCancellationRequested)
                 {
                     stopWatch.Reset();
                     return;
@@ -220,7 +217,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
 
-            if (!cancellationTokenSource.IsCancellationRequested)
+            if (!localCancellationTokenSource.IsCancellationRequested)
             {
                 var handler = elapsed;
                 handler?.Invoke(this, elapsedEventArgs);

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -166,8 +166,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
     private void RunTimer(CancellationTokenSource localCancellationTokenSource)
     {
-        var stopWatch = new Stopwatch();
-        stopWatch.Start();
+        var stopWatch = Stopwatch.StartNew();
         var nextTriggerTicks = intervalTicks;
         var skippedIntervals = 0L;
         var lastFireTicks = 0L;

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -241,7 +241,8 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
             if (!autoReset)
             {
-                running = false;
+                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
+                localCancellationTokenSource.Cancel();
                 handler?.Invoke(this, elapsedEventArgs);
                 break;
             }
@@ -253,5 +254,6 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     public void Dispose()
     {
         Stop();
+        elapsed = null;
     }
 }

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -172,9 +172,9 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
         var lastFireTicks = 0L;
 
         while (!localCancellationTokenSource.IsCancellationRequested)
-        {      
+        {
             while (true)
-            {                
+            {
                 var diffTicks = nextTriggerTicks - stopWatch.ElapsedTicks;
                 if (diffTicks <= 0)
                 {
@@ -196,53 +196,56 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
                 if (localCancellationTokenSource.IsCancellationRequested)
                 {
-                    stopWatch.Reset();
-                    return;
-                }                 
+                    break;
+                }
             }
 
-            nextTriggerTicks += intervalTicks;
+            if (localCancellationTokenSource.IsCancellationRequested)
+            {
+                break;
+            }
+
             var currentTicks = stopWatch.ElapsedTicks;
             var lastFireTicksLocal = lastFireTicks;
             lastFireTicks = currentTicks;
 
-            if (skipMissedIntervals)
+            if (autoReset)
             {
-                while (nextTriggerTicks < currentTicks)
+                nextTriggerTicks += intervalTicks;
+
+                if (skipMissedIntervals)
                 {
-                    nextTriggerTicks += intervalTicks;
-                    if (skippedIntervals < long.MaxValue)
+                    while (nextTriggerTicks < currentTicks)
                     {
-                        skippedIntervals++;
+                        nextTriggerTicks += intervalTicks;
+                        if (skippedIntervals < long.MaxValue)
+                        {
+                            skippedIntervals++;
+                        }
                     }
                 }
-            }
 
-            if (stopWatch.Elapsed.TotalHours >= 1)
-            {
-                var remaining = nextTriggerTicks - currentTicks;
-                stopWatch.Restart();
-                nextTriggerTicks = remaining;
-                lastFireTicks = 0L;
+                if (stopWatch.Elapsed.TotalHours >= 1)
+                {
+                    var remaining = nextTriggerTicks - currentTicks;
+                    stopWatch.Restart();
+                    nextTriggerTicks = remaining;
+                    lastFireTicks = 0L;
+                }
             }
 
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
+            var handler = elapsed;
 
             if (!autoReset)
             {
                 running = false;
-                stopWatch.Reset();
-                var handler = elapsed;
                 handler?.Invoke(this, elapsedEventArgs);
                 break;
             }
 
-            if (!localCancellationTokenSource.IsCancellationRequested)
-            {
-                var handler = elapsed;
-                handler?.Invoke(this, elapsedEventArgs);
-            }
+            handler?.Invoke(this, elapsedEventArgs);
         }
     }
 

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -32,7 +32,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
             }
 
             intervalMs = (float)value;
-            intervalTicks = (long)(intervalMs * ticksPerMillisecond);
+            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * ticksPerMillisecond));
         }
     }
 
@@ -167,7 +167,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     private void RunTimer(CancellationTokenSource localCancellationTokenSource)
     {
         var stopWatch = Stopwatch.StartNew();
-        var nextTriggerTicks = intervalTicks;
+        var nextTriggerTicks = Interlocked.Read(ref intervalTicks);
         var skippedIntervals = 0L;
         var lastFireTicks = 0L;
 
@@ -211,13 +211,14 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
             if (autoReset)
             {
-                nextTriggerTicks += intervalTicks;
+                var interval = Interlocked.Read(ref intervalTicks);
+                nextTriggerTicks += interval;
 
                 if (skipMissedIntervals)
                 {
                     while (nextTriggerTicks < currentTicks)
                     {
-                        nextTriggerTicks += intervalTicks;
+                        nextTriggerTicks += interval;
                         if (skippedIntervals < long.MaxValue)
                         {
                             skippedIntervals++;

--- a/QuickTickLib/QuickTickElapsedEventArgs.cs
+++ b/QuickTickLib/QuickTickElapsedEventArgs.cs
@@ -1,9 +1,9 @@
-﻿namespace QuickTickLib;
+namespace QuickTickLib;
 
-public class QuickTickElapsedEventArgs
+public sealed class QuickTickElapsedEventArgs
 {
     public TimeSpan TimeSinceLastInterval { get; }
-    public long SkippedIntervals { get; }  
+    public long SkippedIntervals { get; }
 
     public QuickTickElapsedEventArgs(TimeSpan timeSinceLastInterval, long skippedIntervals)
     {

--- a/QuickTickLib/QuickTickHandleResources.cs
+++ b/QuickTickLib/QuickTickHandleResources.cs
@@ -8,7 +8,7 @@ internal sealed class QuickTickHandleResources : IDisposable
     public readonly SafeWaitCompletionPacketHandle WaitIocpHandle;
     public readonly SafeTimerHandle TimerHandle;
 
-    public QuickTickHandleResources(double interval)
+    public QuickTickHandleResources()
     {
         try
         {

--- a/QuickTickLib/QuickTickHandleResources.cs
+++ b/QuickTickLib/QuickTickHandleResources.cs
@@ -1,0 +1,52 @@
+﻿using System.Runtime.InteropServices;
+
+namespace QuickTickLib;
+
+internal sealed class QuickTickHandleResources : IDisposable
+{
+    public readonly SafeIoCompletionPortHandle IocpHandle;
+    public readonly SafeWaitCompletionPacketHandle WaitIocpHandle;
+    public readonly SafeTimerHandle TimerHandle;
+
+    public QuickTickHandleResources(double interval)
+    {
+        try
+        {
+            IocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
+            if (IocpHandle.IsInvalid)
+            {
+                throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
+            }
+
+            int status = Win32Interop.NtCreateWaitCompletionPacket(out WaitIocpHandle, QuickTickHelper.NtCreateWaitCompletionPacketAccessRights, IntPtr.Zero);
+            if (status != 0)
+            {
+                throw new InvalidOperationException($"NtCreateWaitCompletionPacket failed: {status:X8}");
+            }
+            if (WaitIocpHandle.IsInvalid)
+            {
+                throw new InvalidOperationException("NtCreateWaitCompletionPacket returned success but the handle is invalid.");
+            }
+
+            TimerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
+            if (TimerHandle.IsInvalid)
+            {
+                throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
+            }
+        }
+        catch
+        {
+            IocpHandle?.Dispose();
+            WaitIocpHandle?.Dispose();
+            TimerHandle?.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        WaitIocpHandle.Dispose();
+        IocpHandle.Dispose();
+        TimerHandle.Dispose();
+    }
+}

--- a/QuickTickLib/QuickTickHelper.cs
+++ b/QuickTickLib/QuickTickHelper.cs
@@ -7,18 +7,18 @@ internal static class QuickTickHelper
     internal const uint NtCreateWaitCompletionPacketAccessRights = (uint)Win32Interop.TimerAccessMask.TIMER_MODIFY_STATE | (uint)Win32Interop.TimerAccessMask.TIMER_QUERY_STATE;
     internal const uint CreateWaitableTimerExWAccessRights = (uint)Win32Interop.TimerAccessMask.TIMER_MODIFY_STATE | (uint)Win32Interop.TimerAccessMask.SYNCHRONIZE;
     private const int MinRequiredWindowsBuildNumber = 17134; // This is the build number of Windows 10 Version 1803
-    private static readonly Version? windowsVersion = GetWindowsVersion();
+    private static readonly Version? WindowsVersion = GetWindowsVersion();
 
     internal static bool PlatformSupportsQuickTick()
     {
-        if (windowsVersion is null)
+        if (WindowsVersion is null)
         {
             return false;
         }
 
-        // Current Windows 10 versions / Server 2019+ will support this functions. The minimal supported windows version
-        // is Version 1803 of Windows 10 as in that version the Highprecision flag was added to CreateWaitableTimerExW which this library relies on
-        if (windowsVersion.Major >= 10 && windowsVersion.Build >= MinRequiredWindowsBuildNumber)
+        // Current Windows 10 versions / Server 2019+ will support this functions. The minimal supported Windows version
+        // is Version 1803 of Windows 10 as in that version the HighPrecision flag was added to CreateWaitableTimerExW which this library relies on
+        if (WindowsVersion is { Major: >= 10, Build: >= MinRequiredWindowsBuildNumber })
         {
             return true;
         }

--- a/QuickTickLib/QuickTickLib.csproj
+++ b/QuickTickLib/QuickTickLib.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="QuickTickTimingReportGenerator" />
+    <InternalsVisibleTo Include="QuickTickTests" />
   </ItemGroup>
 
 </Project>

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -22,10 +22,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     public double Interval
     {
         get => timer.Interval;
-        set
-        {
-            timer.Interval = value;
-        }
+        set => timer.Interval = value;
     }
 
     public bool AutoReset
@@ -37,10 +34,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     public bool SkipMissedIntervals 
     {
         get => skipMissedIntervals;
-        set
-        {
-            skipMissedIntervals = value;
-        }
+        set => skipMissedIntervals = value;
     }
 
     public ThreadPriority Priority

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -18,6 +18,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     private QuickTickElapsedEventHandler? elapsed;
     private readonly Stopwatch stopWatch = new();
     private long lastFireTicks;
+    private readonly object stateLock = new();
 
     public double Interval
     {
@@ -65,38 +66,44 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
     public void Start()
     {
-        if (running)
+        lock (stateLock)
         {
-            return;
+            if (running)
+            {
+                return;
+            }
+            stopWatch.Restart();
+
+            running = true;
+            eventQueue = [];
+            skippedIntervals = 0;
+            lastFireTicks = 0;
+
+            workerThread = new Thread(() => Run(eventQueue))
+            {
+                IsBackground = true,
+                Priority = Priority
+            };
+
+            workerThread.Start();
+            timer.Start();
         }
-        stopWatch.Restart();
-
-        running = true;
-        eventQueue = [];
-        skippedIntervals = 0;
-        lastFireTicks = 0;
-
-        workerThread = new Thread(() => Run(eventQueue))
-        {
-            IsBackground = true,
-            Priority = Priority
-        };
-
-        workerThread.Start();
-        timer.Start();
     }
 
     public void Stop()
     {
-        if (!running)
+        lock (stateLock)
         {
-            return;
-        }
+            if (!running)
+            {
+                return;
+            }
 
-        timer.Stop();
-        running = false;
-        eventQueue?.CompleteAdding();
-        stopWatch.Reset();
+            timer.Stop();
+            running = false;
+            eventQueue?.CompleteAdding();
+            stopWatch.Reset();
+        }
     }
 
     private void OnElapsedInternal(object? sender, ElapsedEventArgs e)

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -98,10 +98,17 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             {
                 return;
             }
-
-            timer.Stop();
+            
             running = false;
+            timer.Stop();
             eventQueue?.CompleteAdding();
+
+            if (Thread.CurrentThread != workerThread)
+            {
+                workerThread?.Join();
+            }
+            workerThread = null;
+            
             stopWatch.Reset();
         }
     }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -1,4 +1,4 @@
-﻿// Some parts of the code are inspired by György Kőszeg's HighRes Timer: https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs
+// Some parts of the code are inspired by György Kőszeg's HighRes Timer: https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -14,10 +14,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     private volatile bool skipMissedIntervals;
     private ThreadPriority threadPriority = ThreadPriority.Normal;
     private Thread? workerThread;
-    private long skippedIntervals;
     private QuickTickElapsedEventHandler? elapsed;
-    private readonly Stopwatch stopWatch = new();
-    private long lastFireTicks;
     private readonly object stateLock = new();
 
     public double Interval
@@ -32,7 +29,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
         set => timer.AutoReset = value;
     }
 
-    public bool SkipMissedIntervals 
+    public bool SkipMissedIntervals
     {
         get => skipMissedIntervals;
         set => skipMissedIntervals = value;
@@ -47,7 +44,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             if (workerThread != null)
             {
                 workerThread.Priority = value;
-            }         
+            }
         }
     }
 
@@ -72,12 +69,9 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             {
                 return;
             }
-            stopWatch.Restart();
 
             running = true;
             eventQueue = [];
-            skippedIntervals = 0;
-            lastFireTicks = 0;
 
             workerThread = new Thread(() => Run(eventQueue))
             {
@@ -98,7 +92,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             {
                 return;
             }
-            
+
             running = false;
             timer.Stop();
             eventQueue?.CompleteAdding();
@@ -108,8 +102,6 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
                 workerThread?.Join();
             }
             workerThread = null;
-            
-            stopWatch.Reset();
         }
     }
 
@@ -120,12 +112,16 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
     private void Run(BlockingCollection<bool> localEventQueue)
     {
+        var stopWatch = Stopwatch.StartNew();
+        var lastFireTicks = 0L;
+        var skippedIntervals = 0L;
+
         while (running)
         {
             // Wait for at least one callback
             if (!localEventQueue.TryTake(out _, Timeout.Infinite))
             {
-                break; // In this case the CompleteAdding was called
+                break; // CompleteAdding was called
             }
 
             // If skipping is enabled, drain queue and only keep the latest
@@ -152,8 +148,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
             if (!AutoReset)
             {
-                running = false;
-                stopWatch.Reset();
+                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
                 var handler = elapsed;
                 handler?.Invoke(this, elapsedEventArgs);
                 break;

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -143,17 +143,19 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
 
-            if (running)
-            {
-                var handler = elapsed;
-                handler?.Invoke(this, elapsedEventArgs);
-            }
-
             if (!AutoReset)
             {
                 running = false;
                 stopWatch.Reset();
+                var handler = elapsed;
+                handler?.Invoke(this, elapsedEventArgs);
                 break;
+            }
+
+            if (running)
+            {
+                var handler = elapsed;
+                handler?.Invoke(this, elapsedEventArgs);
             }
         }
     }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -6,7 +6,7 @@ using System.Timers;
 
 namespace QuickTickLib;
 
-internal class QuickTickTimerFallback : IQuickTickTimer
+internal sealed class QuickTickTimerFallback : IQuickTickTimer
 {
     private readonly System.Timers.Timer timer;
     private BlockingCollection<bool>? eventQueue;

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -159,7 +159,8 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
             if (!AutoReset)
             {
-                running = false;
+                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
+                localCancellationTokenSource.Cancel();
                 handler?.Invoke(this, elapsedEventArgs);
                 break;
             }
@@ -170,9 +171,8 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
     public void Dispose()
     {
+        Stop();
         timer.Dispose();
-        running = false;
-        cancellationTokenSource?.Cancel();
-        eventQueue?.CompleteAdding();
+        elapsed = null;
     }
 }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -113,7 +113,8 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
     private void OnElapsedInternal(object? sender, ElapsedEventArgs e)
     {
-        eventQueue?.Add(true);
+        // Use tryAdd because the timer could still fire after Stop() which would cause exception because Stop() also call CompleteAdding() on the queue
+        eventQueue?.TryAdd(true);
     }
 
     private void Run(CancellationTokenSource localCancellationTokenSource, BlockingCollection<bool> localEventQueue)

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -12,6 +12,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     private BlockingCollection<bool>? eventQueue;
     private volatile bool running;
     private volatile bool skipMissedIntervals;
+    private int disposedState;
     private ThreadPriority threadPriority = ThreadPriority.Normal;
     private CancellationTokenSource? cancellationTokenSource;
     private Thread? workerThread;
@@ -42,7 +43,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
         set
         {
             threadPriority = value;
-            if (workerThread != null)
+            if (workerThread is { IsAlive: true })
             {
                 workerThread.Priority = value;
             }
@@ -146,7 +147,10 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
                 {
                     while (localEventQueue.TryTake(out _))
                     {
-                        skippedIntervals++;
+                        if (skippedIntervals < long.MaxValue)
+                        {
+                            skippedIntervals++;
+                        }
                     }
                 }
 
@@ -175,8 +179,19 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
     public void Dispose()
     {
-        Stop();
-        timer.Dispose();
-        elapsed = null;
+        if (Interlocked.Exchange(ref disposedState, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            Stop();
+        }
+        finally
+        {
+            timer.Dispose();
+            elapsed = null;
+        }
     }
 }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -13,6 +13,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     private volatile bool running;
     private volatile bool skipMissedIntervals;
     private ThreadPriority threadPriority = ThreadPriority.Normal;
+    private CancellationTokenSource? cancellationTokenSource;
     private Thread? workerThread;
     private QuickTickElapsedEventHandler? elapsed;
     private readonly object stateLock = new();
@@ -71,14 +72,17 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             }
 
             running = true;
-            eventQueue = [];
+            var cts = new CancellationTokenSource();
+            var queue = new BlockingCollection<bool>();
 
-            workerThread = new Thread(() => Run(eventQueue))
+            workerThread = new Thread(() => Run(cts, queue))
             {
                 IsBackground = true,
                 Priority = Priority
             };
 
+            cancellationTokenSource = cts;
+            eventQueue = queue;
             workerThread.Start();
             timer.Start();
         }
@@ -94,6 +98,8 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
             }
 
             running = false;
+            cancellationTokenSource?.Cancel();
+            cancellationTokenSource = null;
             timer.Stop();
             eventQueue?.CompleteAdding();
 
@@ -110,22 +116,22 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
         eventQueue?.Add(true);
     }
 
-    private void Run(BlockingCollection<bool> localEventQueue)
+    private void Run(CancellationTokenSource localCancellationTokenSource, BlockingCollection<bool> localEventQueue)
     {
         var stopWatch = Stopwatch.StartNew();
         var lastFireTicks = 0L;
         var skippedIntervals = 0L;
 
-        while (running)
+        while (!localCancellationTokenSource.IsCancellationRequested)
         {
             if (!localEventQueue.TryTake(out _, Timeout.Infinite))
             {
                 break; // CompleteAdding was called
             }
 
-            if (!running)
+            if (localCancellationTokenSource.IsCancellationRequested)
             {
-                break; // Stop() set running=false before CompleteAdding; item was already in queue
+                break;
             }
 
             // If skipping is enabled, drain queue and only keep the latest
@@ -166,6 +172,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     {
         timer.Dispose();
         running = false;
+        cancellationTokenSource?.Cancel();
         eventQueue?.CompleteAdding();
     }
 }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -134,23 +134,26 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
                 break;
             }
 
-            // If skipping is enabled, drain queue and only keep the latest
-            if (skipMissedIntervals && localEventQueue.Count > 0)
-            {
-                while (localEventQueue.TryTake(out _))
-                {
-                    skippedIntervals++;
-                }
-            }
-
             var currentTicks = stopWatch.ElapsedTicks;
             var lastFireTicksLocal = lastFireTicks;
             lastFireTicks = currentTicks;
 
-            if (stopWatch.Elapsed.TotalHours >= 1)
+            if (AutoReset)
             {
-                stopWatch.Restart();
-                lastFireTicks = 0;
+                // If skipping is enabled, drain queue and only keep the latest
+                if (skipMissedIntervals && localEventQueue.Count > 0)
+                {
+                    while (localEventQueue.TryTake(out _))
+                    {
+                        skippedIntervals++;
+                    }
+                }
+
+                if (stopWatch.Elapsed.TotalHours >= 1)
+                {
+                    stopWatch.Restart();
+                    lastFireTicks = 0;
+                }
             }
 
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -118,10 +118,14 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
         while (running)
         {
-            // Wait for at least one callback
             if (!localEventQueue.TryTake(out _, Timeout.Infinite))
             {
                 break; // CompleteAdding was called
+            }
+
+            if (!running)
+            {
+                break; // Stop() set running=false before CompleteAdding; item was already in queue
             }
 
             // If skipping is enabled, drain queue and only keep the latest
@@ -145,20 +149,16 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
+            var handler = elapsed;
 
             if (!AutoReset)
             {
-                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
-                var handler = elapsed;
+                running = false;
                 handler?.Invoke(this, elapsedEventArgs);
                 break;
             }
 
-            if (running)
-            {
-                var handler = elapsed;
-                handler?.Invoke(this, elapsedEventArgs);
-            }
+            handler?.Invoke(this, elapsedEventArgs);
         }
     }
 

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -1,4 +1,4 @@
-﻿// Some parts of the code are inspired by György Kőszeg's HighRes Timer: https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs
+// Some parts of the code are inspired by György Kőszeg's HighRes Timer: https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -8,17 +8,14 @@ namespace QuickTickLib;
 internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 {
     private readonly QuickTickHandleResources handles;
-    private static readonly IntPtr SuccessCompletionKey = new(1);
+    private static readonly IntPtr CancelCompletionKey = IntPtr.Zero;
 
     private volatile bool autoReset;
     private volatile bool skipMissedIntervals;
     private volatile bool running;
     private volatile float intervalMs;
     private long intervalTicks;
-    private long nextFireTicks;
-    private long lastFireTicks;
-    private long totalSkippedIntervals;
-    private readonly Stopwatch stopWatch = new();
+    private int currentRunKey;
 
     private int disposedState;
     private readonly object stateLock = new();
@@ -70,7 +67,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             if (completionThread is { IsAlive: true })
             {
                 completionThread.Priority = value;
-            }           
+            }
         }
     }
 
@@ -78,7 +75,6 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     {
         AutoReset = true;
         Interval = interval;
-
         handles = new QuickTickHandleResources();
     }
 
@@ -90,19 +86,14 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             {
                 return;
             }
-            stopWatch.Restart();
 
             running = true;
-
-            Interlocked.Exchange(ref nextFireTicks, Interlocked.Read(ref intervalTicks));
-            Interlocked.Exchange(ref totalSkippedIntervals, 0L);
-            Interlocked.Exchange(ref lastFireTicks, 0L);
-
-            SetTimer();
-
             var cts = new CancellationTokenSource();
 
-            completionThread = new Thread(() => CompletionThreadLoop(cts))
+            var key = ++currentRunKey == 0 ? ++currentRunKey : currentRunKey;
+            var runKey = new IntPtr(key);
+
+            completionThread = new Thread(() => CompletionThreadLoop(cts, runKey))
             {
                 IsBackground = true,
                 Priority = Priority
@@ -132,15 +123,13 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             {
                 // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
                 // If called from the same thread we know we are called from the event handler code therefore we are not waiting on an event and don't need to send a dummy completion
-                Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
+                Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, CancelCompletionKey, IntPtr.Zero);
 
                 completionThread?.Join();
             }
             completionThread = null;
 
             Win32Interop.NtCancelWaitCompletionPacket(handles.WaitIocpHandle, true);
-           
-            stopWatch.Reset();
         }
     }
 
@@ -162,86 +151,91 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         }
     }
 
-    private void SetTimer()
+    private void CompletionThreadLoop(CancellationTokenSource localCancellationTokenSource, IntPtr runKey)
     {
-        long dueTime = Interlocked.Read(ref nextFireTicks) - stopWatch.ElapsedTicks; // Calculate absolute expiration
-        dueTime = dueTime < 0 ? 0 : -dueTime; // Ensure valid time
+        Console.WriteLine($"{nameof(CompletionThreadLoop)} started with {runKey}");
+        
+        var stopWatch = Stopwatch.StartNew();
+        var nextFireTicks = Interlocked.Read(ref intervalTicks);
+        var lastFireTicks = 0L;
+        var skippedIntervals = 0L;
+
+        SetTimer(stopWatch, nextFireTicks, runKey);
+
+        while (!localCancellationTokenSource.IsCancellationRequested)
+        {
+            var getStatusResult = Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
+
+            if (localCancellationTokenSource.IsCancellationRequested || !getStatusResult)
+            {
+                break;
+            }
+
+            if (lpCompletionKey != runKey)
+            {
+                continue; // Ignore stale packet from a previous run or old cancel events; Cancel packet only used to get out of wait the actual cancel is done via the cts
+            }
+
+            var currentTicks = stopWatch.ElapsedTicks;
+            var lastFireTicksLocal = lastFireTicks;
+            lastFireTicks = currentTicks;
+
+            if (autoReset)
+            {
+                var interval = Interlocked.Read(ref intervalTicks);
+                nextFireTicks += interval;
+
+                if (skipMissedIntervals)
+                {
+                    while (nextFireTicks < currentTicks)
+                    {
+                        nextFireTicks += interval;
+                        if (skippedIntervals < long.MaxValue)
+                        {
+                            skippedIntervals++;
+                        }
+                    }
+                }
+
+                if (stopWatch.Elapsed.TotalHours >= 1)
+                {
+                    var remaining = nextFireTicks - currentTicks;
+                    stopWatch.Restart();
+                    nextFireTicks = remaining;
+                    lastFireTicks = 0;
+                }
+
+                SetTimer(stopWatch, nextFireTicks, runKey);
+            }
+            else
+            {
+                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
+                localCancellationTokenSource.Cancel();
+            }
+
+            var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
+            var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
+
+            var handler = elapsed;
+            handler?.Invoke(this, elapsedEventArgs);
+        }
+    }
+    
+    private void SetTimer(Stopwatch stopWatch, long nextFireTicks, IntPtr runKey)
+    {
+        long dueTime = nextFireTicks - stopWatch.ElapsedTicks;
+        dueTime = dueTime < 0 ? 0 : -dueTime; // Negative = relative time for SetWaitableTimer
 
         if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false)) // Setting the period to 0 makes the timer fire exactly once
         {
             throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
         }
 
-        int status = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, SuccessCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
+        int status = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, runKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
 
         if (status != 0)
         {
             throw new InvalidOperationException($"NtAssociateWaitCompletionPacket failed: {status:X8}");
-        }
-    }
-
-    private void CompletionThreadLoop(CancellationTokenSource localCancellationTokenSource)
-    {
-        while (!localCancellationTokenSource.IsCancellationRequested)
-        {
-            var getStatusResult = Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
-
-            // Check if we were canceled while waiting (external cancel / cancel from other thread). The secondary check should not be needed
-            if (localCancellationTokenSource.IsCancellationRequested || !getStatusResult)
-            {
-                break;
-            }
-
-            if (lpCompletionKey != SuccessCompletionKey)
-            {
-                continue; // In rare timing cases e.g. when external Stop is called while in user code the old invalid completion packet to stop the wait might still be present so we ignore it;
-            }
-
-            var currentTicks = stopWatch.ElapsedTicks;
-            var lastFireTicksLocal = Interlocked.Read(ref lastFireTicks);
-            Interlocked.Exchange(ref lastFireTicks, currentTicks);
-            var skippedIntervals = Interlocked.Read(ref totalSkippedIntervals);
-
-            if (autoReset)
-            {
-                var interval = Interlocked.Read(ref intervalTicks);
-                var nextTicks = Interlocked.Add(ref nextFireTicks, interval);           
-
-                if (skipMissedIntervals)
-                {
-                    while (nextTicks < currentTicks)
-                    {
-                        nextTicks = Interlocked.Add(ref nextFireTicks, interval);
-                        if (skippedIntervals < long.MaxValue)
-                        {
-                            skippedIntervals++;
-                        }
-                    }
-                    Interlocked.Exchange(ref totalSkippedIntervals, skippedIntervals);
-                }
-
-                if (stopWatch.Elapsed.TotalHours >= 1)
-                {
-                    var remaining = nextTicks - currentTicks;
-                    stopWatch.Restart();
-                    Interlocked.Exchange(ref nextFireTicks, remaining);
-                    Interlocked.Exchange(ref lastFireTicks, 0L);
-                }
-
-                SetTimer();
-            }
-            else
-            {
-                running = false; // Same logic as in System.Timers.Timer resetting "Enabled" (here: isRunning) back before running the handler if autoReset is disabled
-                stopWatch.Reset();
-                localCancellationTokenSource.Cancel();
-            }
-    
-            var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
-            var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
-
-            var handler = elapsed;
-            handler?.Invoke(this, elapsedEventArgs);
         }
     }
 }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -1,16 +1,13 @@
 ﻿// Some parts of the code are inspired by György Kőszeg's HighRes Timer: https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs
 
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace QuickTickLib;
 
-internal class QuickTickTimerImplementation : IQuickTickTimer
+internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 {
-    private readonly SafeIoCompletionPortHandle iocpHandle;
-    private readonly SafeWaitCompletionPacketHandle waitIocpHandle;
-    private readonly SafeTimerHandle timerHandle;
+    private readonly QuickTickHandleResources handles;
 
     private static readonly IntPtr successCompletionKey = new(1);
 
@@ -29,11 +26,6 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
     private QuickTickElapsedEventHandler? elapsed;
 
     private int disposedState;
-
-    ~QuickTickTimerImplementation()
-    {
-        Dispose(false);
-    }
 
     public event QuickTickElapsedEventHandler? Elapsed
     {
@@ -83,40 +75,10 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
 
     public QuickTickTimerImplementation(double interval)
     {
-        try
-        {
-            iocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
-            if (iocpHandle.IsInvalid)
-            {
-                throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
-            }
+        AutoReset = true;
+        Interval = interval;
 
-            int status = Win32Interop.NtCreateWaitCompletionPacket(out waitIocpHandle, QuickTickHelper.NtCreateWaitCompletionPacketAccessRights, IntPtr.Zero);
-            if (status != 0)
-            {
-                throw new InvalidOperationException($"NtCreateWaitCompletionPacket failed: {status:X8}");
-            }
-            if (waitIocpHandle.IsInvalid)
-            {
-                throw new InvalidOperationException("NtCreateWaitCompletionPacket returned success but the handle is invalid.");
-            }
-
-            timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
-            if (timerHandle.IsInvalid)
-            {
-                throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
-            }
-
-            AutoReset = true;
-            Interval = interval;
-        }
-        catch
-        {
-            iocpHandle?.Dispose();
-            waitIocpHandle?.Dispose();
-            timerHandle?.Dispose();
-            throw;
-        }
+        handles = new QuickTickHandleResources(interval);
     }
 
     public void Start()
@@ -151,13 +113,13 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         }
 
         isRunning = false;
-        if (!timerHandle.IsInvalid)
+        if (!handles.TimerHandle.IsInvalid)
         {
-            Win32Interop.CancelWaitableTimer(timerHandle);
+            Win32Interop.CancelWaitableTimer(handles.TimerHandle);
         }
 
         // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
-        Win32Interop.PostQueuedCompletionStatus(iocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
+        Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
 
         if (Thread.CurrentThread != completionThread)
         {
@@ -165,35 +127,29 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         }
         completionThread = null;
 
-        if (!waitIocpHandle.IsInvalid)
+        if (!handles.WaitIocpHandle.IsInvalid)
         {
-            Win32Interop.NtCancelWaitCompletionPacket(waitIocpHandle, true);
+            Win32Interop.NtCancelWaitCompletionPacket(handles.WaitIocpHandle, true);
         }
         stopWatch.Reset();
     }
 
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    private void Dispose(bool disposing)
-    {
         if (Interlocked.Exchange(ref disposedState, 1) == 1)
         {
             return;
         }
 
-        if (disposing)
+        try
         {
             Stop();
-            elapsed = null;
         }
-
-        waitIocpHandle.Dispose();
-        iocpHandle.Dispose();
-        timerHandle.Dispose();
+        finally
+        {
+            elapsed = null;
+            handles.Dispose();
+        }
     }
 
     private void SetTimer()
@@ -201,12 +157,12 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         long dueTime = Interlocked.Read(ref nextFireTicks) - stopWatch.ElapsedTicks; // Calculate absolute expiration
         dueTime = dueTime < 0 ? 0 : -dueTime; // Ensure valid time
 
-        if (!Win32Interop.SetWaitableTimer(timerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false))
+        if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false))
         {
             throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
         }
 
-        int status = Win32Interop.NtAssociateWaitCompletionPacket(waitIocpHandle, iocpHandle, timerHandle, successCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
+        int status = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, successCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
 
         if (status != 0)
         {
@@ -218,11 +174,11 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
     {
         while (isRunning)
         {
-            var getStatusResult = Win32Interop.GetQueuedCompletionStatus(iocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
+            var getStatusResult = Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
 
             if (!getStatusResult)
             {
-                if (!Win32Interop.GetHandleInformation(iocpHandle, out _))
+                if (!Win32Interop.GetHandleInformation(handles.IocpHandle, out _))
                 {
                     isRunning = false;
                     break;
@@ -272,9 +228,9 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
             {
                 isRunning = false;
                 stopWatch.Reset();
-                if (!timerHandle.IsInvalid)
+                if (!handles.TimerHandle.IsInvalid)
                 {
-                    Win32Interop.CancelWaitableTimer(timerHandle);
+                    Win32Interop.CancelWaitableTimer(handles.TimerHandle);
                 }
             }
     

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -12,7 +12,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
     private volatile bool autoReset;
     private volatile bool skipMissedIntervals;
-    private volatile bool isRunning;
+    private volatile bool running;
     private volatile float intervalMs;
     private long intervalTicks;
     private long nextFireTicks;
@@ -86,13 +86,13 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     {
         lock (stateLock)
         {
-            if (isRunning)
+            if (running)
             {
                 return;
             }
             stopWatch.Restart();
 
-            isRunning = true;
+            running = true;
 
             Interlocked.Exchange(ref nextFireTicks, Interlocked.Read(ref intervalTicks));
             Interlocked.Exchange(ref totalSkippedIntervals, 0L);
@@ -117,12 +117,12 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     {
         lock (stateLock)
         {
-            if (!isRunning)
+            if (!running)
             {
                 return;
             }
 
-            isRunning = false;
+            running = false;
             cancellationTokenSource?.Cancel();
             cancellationTokenSource = null;
 
@@ -232,7 +232,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             }
             else
             {
-                isRunning = false; // Same logic as in System.Timers.Timer resetting "Enabled" (here: isRunning) back before running the handler if autoReset is disabled
+                running = false; // Same logic as in System.Timers.Timer resetting "Enabled" (here: isRunning) back before running the handler if autoReset is disabled
                 stopWatch.Reset();
                 localCancellationTokenSource.Cancel();
             }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -78,7 +78,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         AutoReset = true;
         Interval = interval;
 
-        handles = new QuickTickHandleResources(interval);
+        handles = new QuickTickHandleResources();
     }
 
     public void Start()

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -153,8 +153,6 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
     private void CompletionThreadLoop(CancellationTokenSource localCancellationTokenSource, IntPtr runKey)
     {
-        Console.WriteLine($"{nameof(CompletionThreadLoop)} started with {runKey}");
-        
         var stopWatch = Stopwatch.StartNew();
         var nextFireTicks = Interlocked.Read(ref intervalTicks);
         var lastFireTicks = 0L;

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -129,6 +129,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             }
             completionThread = null;
 
+            // Call cancels the wait completion packets; needed because there can not be two consecutive calls to NtAssociateWaitCompletionPacket which could happen in some stop restart scenarios
             Win32Interop.NtCancelWaitCompletionPacket(handles.WaitIocpHandle, true);
         }
     }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -7,9 +7,9 @@ namespace QuickTickLib;
 
 internal class QuickTickTimerImplementation : IQuickTickTimer
 {
-    private readonly IntPtr iocpHandle;
-    private readonly IntPtr waitIocpHandle;
-    private readonly IntPtr timerHandle;
+    private readonly SafeIoCompletionPortHandle iocpHandle;
+    private readonly SafeWaitCompletionPacketHandle waitIocpHandle;
+    private readonly SafeTimerHandle timerHandle;
 
     private static readonly IntPtr successCompletionKey = new(1);
 
@@ -86,7 +86,7 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         Interval = interval;
 
         iocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
-        if (iocpHandle == IntPtr.Zero)
+        if (iocpHandle.IsInvalid)
         {
             throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
         }
@@ -98,7 +98,7 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         }
 
         timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
-        if (timerHandle == IntPtr.Zero)
+        if (timerHandle.IsInvalid)
         {
             throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
         }
@@ -136,7 +136,7 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         }
 
         isRunning = false;
-        if (timerHandle != IntPtr.Zero)
+        if (!timerHandle.IsInvalid)
         {
             Win32Interop.CancelWaitableTimer(timerHandle);
         }
@@ -150,7 +150,7 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
         }
         completionThread = null;
 
-        if (waitIocpHandle != IntPtr.Zero)
+        if (!waitIocpHandle.IsInvalid)
         {
             Win32Interop.NtCancelWaitCompletionPacket(waitIocpHandle, true);
         }
@@ -176,20 +176,9 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
             elapsed = null;
         }
 
-        if (waitIocpHandle != IntPtr.Zero)
-        {
-            Win32Interop.CloseHandle(waitIocpHandle);
-        }
-
-        if (iocpHandle != IntPtr.Zero)
-        {
-            Win32Interop.CloseHandle(iocpHandle);
-        }
-
-        if (timerHandle != IntPtr.Zero)
-        {
-            Win32Interop.CloseHandle(timerHandle);
-        }
+        waitIocpHandle.Dispose();
+        iocpHandle.Dispose();
+        timerHandle.Dispose();
     }
 
     private void SetTimer()
@@ -268,7 +257,7 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
             {
                 isRunning = false;
                 stopWatch.Reset();
-                if (timerHandle != IntPtr.Zero)
+                if (!timerHandle.IsInvalid)
                 {
                     Win32Interop.CancelWaitableTimer(timerHandle);
                 }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -8,7 +8,6 @@ namespace QuickTickLib;
 internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 {
     private readonly QuickTickHandleResources handles;
-
     private static readonly IntPtr successCompletionKey = new(1);
 
     private volatile bool autoReset;
@@ -21,12 +20,13 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     private long totalSkippedIntervals;
     private readonly Stopwatch stopWatch = new();
 
+    private int disposedState;
+    private readonly object stateLock = new();
+
     private CancellationTokenSource? cancellationTokenSource;
     private Thread? completionThread;
     private ThreadPriority threadPriority = ThreadPriority.Normal;
     private QuickTickElapsedEventHandler? elapsed;
-
-    private int disposedState;
 
     public event QuickTickElapsedEventHandler? Elapsed
     {
@@ -84,63 +84,64 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
     public void Start()
     {
-        if (isRunning)
+        lock (stateLock)
         {
-            return;
+            if (isRunning)
+            {
+                return;
+            }
+            stopWatch.Restart();
+
+            isRunning = true;
+
+            Interlocked.Exchange(ref nextFireTicks, Interlocked.Read(ref intervalTicks));
+            Interlocked.Exchange(ref totalSkippedIntervals, 0L);
+            Interlocked.Exchange(ref lastFireTicks, 0L);
+
+            SetTimer();
+
+            var cts = new CancellationTokenSource();
+
+            completionThread = new Thread(() => CompletionThreadLoop(cts))
+            {
+                IsBackground = true,
+                Priority = Priority
+            };
+
+            cancellationTokenSource = cts;
+            completionThread.Start();
         }
-        stopWatch.Restart();
-
-        isRunning = true;
-
-        Interlocked.Exchange(ref nextFireTicks, Interlocked.Read(ref intervalTicks));
-        Interlocked.Exchange(ref totalSkippedIntervals, 0L);
-        Interlocked.Exchange(ref lastFireTicks, 0L);
-
-        SetTimer();
-
-        var cts = new CancellationTokenSource();
-
-        completionThread = new Thread(() => CompletionThreadLoop(cts))
-        {
-            IsBackground = true,
-            Priority = Priority
-        };
-
-        cancellationTokenSource = cts;
-        completionThread.Start();
     }
 
     public void Stop()
     {
-        if (!isRunning)
+        lock (stateLock)
         {
-            return;
-        }
+            if (!isRunning)
+            {
+                return;
+            }
 
-        isRunning = false;
-        cancellationTokenSource?.Cancel();
-        cancellationTokenSource?.Dispose();
+            isRunning = false;
+            cancellationTokenSource?.Cancel();
+            cancellationTokenSource = null;
 
-        if (!handles.TimerHandle.IsInvalid)
-        {
             Win32Interop.CancelWaitableTimer(handles.TimerHandle);
-        }
 
-        if (Thread.CurrentThread != completionThread)
-        {
-            // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
-            // If called from the same thread we know we are called from the event handler code therefore we are not waiting on an event and dont need to send a dummy completion
-            Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
+            if (Thread.CurrentThread != completionThread)
+            {
+                // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
+                // If called from the same thread we know we are called from the event handler code therefore we are not waiting on an event and dont need to send a dummy completion
+                Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
 
-            completionThread?.Join();
-        }
-        completionThread = null;
+                completionThread?.Join();
+            }
+            completionThread = null;
 
-        if (!handles.WaitIocpHandle.IsInvalid)
-        {
             Win32Interop.NtCancelWaitCompletionPacket(handles.WaitIocpHandle, true);
+           
+            stopWatch.Reset();
         }
-        stopWatch.Reset();
     }
 
     public void Dispose()
@@ -166,7 +167,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         long dueTime = Interlocked.Read(ref nextFireTicks) - stopWatch.ElapsedTicks; // Calculate absolute expiration
         dueTime = dueTime < 0 ? 0 : -dueTime; // Ensure valid time
 
-        if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false))
+        if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false)) // Setting the period to 0 makes the timer fire exactly once
         {
             throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
         }
@@ -185,10 +186,15 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         {
             var getStatusResult = Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
 
-            // Check if we were canceled while waiting (External cancel / cancel from other thread). The two secondary checks should not be needed
-            if (cancellationTokenSource.IsCancellationRequested || !getStatusResult || lpCompletionKey != successCompletionKey)
+            // Check if we were canceled while waiting (external cancel / cancel from other thread). The secondary check should not be needed
+            if (cancellationTokenSource.IsCancellationRequested || !getStatusResult)
             {
                 break;
+            }
+
+            if (lpCompletionKey != successCompletionKey)
+            {
+                continue; // In rare timing cases e.g. when external Stop is called while in user code the old invalid completion packet to stop the wait might still be present so we ignore it;
             }
 
             var currentTicks = stopWatch.ElapsedTicks;
@@ -226,12 +232,9 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             }
             else
             {
-                isRunning = false;
+                isRunning = false; // Same logic as in System.Timers.Timer resetting "Enabled" (here: isRunning) back before running the handler if autoreset is disabled
                 stopWatch.Reset();
-                if (!handles.TimerHandle.IsInvalid)
-                {
-                    Win32Interop.CancelWaitableTimer(handles.TimerHandle);
-                }
+                cancellationTokenSource.Cancel();
             }
     
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -8,7 +8,7 @@ namespace QuickTickLib;
 internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 {
     private readonly QuickTickHandleResources handles;
-    private static readonly IntPtr successCompletionKey = new(1);
+    private static readonly IntPtr SuccessCompletionKey = new(1);
 
     private volatile bool autoReset;
     private volatile bool skipMissedIntervals;
@@ -67,7 +67,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         set
         {
             threadPriority = value;
-            if (completionThread != null && completionThread.IsAlive)
+            if (completionThread is { IsAlive: true })
             {
                 completionThread.Priority = value;
             }           
@@ -131,7 +131,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             if (Thread.CurrentThread != completionThread)
             {
                 // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
-                // If called from the same thread we know we are called from the event handler code therefore we are not waiting on an event and dont need to send a dummy completion
+                // If called from the same thread we know we are called from the event handler code therefore we are not waiting on an event and don't need to send a dummy completion
                 Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
 
                 completionThread?.Join();
@@ -172,7 +172,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
         }
 
-        int status = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, successCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
+        int status = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, SuccessCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
 
         if (status != 0)
         {
@@ -180,19 +180,19 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         }
     }
 
-    private void CompletionThreadLoop(CancellationTokenSource cancellationTokenSource)
+    private void CompletionThreadLoop(CancellationTokenSource localCancellationTokenSource)
     {
-        while (!cancellationTokenSource.IsCancellationRequested)
+        while (!localCancellationTokenSource.IsCancellationRequested)
         {
             var getStatusResult = Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
 
             // Check if we were canceled while waiting (external cancel / cancel from other thread). The secondary check should not be needed
-            if (cancellationTokenSource.IsCancellationRequested || !getStatusResult)
+            if (localCancellationTokenSource.IsCancellationRequested || !getStatusResult)
             {
                 break;
             }
 
-            if (lpCompletionKey != successCompletionKey)
+            if (lpCompletionKey != SuccessCompletionKey)
             {
                 continue; // In rare timing cases e.g. when external Stop is called while in user code the old invalid completion packet to stop the wait might still be present so we ignore it;
             }
@@ -232,9 +232,9 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             }
             else
             {
-                isRunning = false; // Same logic as in System.Timers.Timer resetting "Enabled" (here: isRunning) back before running the handler if autoreset is disabled
+                isRunning = false; // Same logic as in System.Timers.Timer resetting "Enabled" (here: isRunning) back before running the handler if autoReset is disabled
                 stopWatch.Reset();
-                cancellationTokenSource.Cancel();
+                localCancellationTokenSource.Cancel();
             }
     
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -1,5 +1,6 @@
 ﻿// Some parts of the code are inspired by György Kőszeg's HighRes Timer: https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
@@ -82,25 +83,35 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
 
     public QuickTickTimerImplementation(double interval)
     {
-        AutoReset = true;
-        Interval = interval;
-
-        iocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
-        if (iocpHandle.IsInvalid)
+        try
         {
-            throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
+            iocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
+            if (iocpHandle.IsInvalid)
+            {
+                throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
+            }
+
+            int status = Win32Interop.NtCreateWaitCompletionPacket(out waitIocpHandle, QuickTickHelper.NtCreateWaitCompletionPacketAccessRights, IntPtr.Zero);
+            if (status != 0)
+            {
+                throw new InvalidOperationException($"NtCreateWaitCompletionPacket failed: {status:X8}");
+            }
+
+            timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
+            if (timerHandle.IsInvalid)
+            {
+                throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
+            }
+
+            AutoReset = true;
+            Interval = interval;
         }
-
-        int status = Win32Interop.NtCreateWaitCompletionPacket(out waitIocpHandle, QuickTickHelper.NtCreateWaitCompletionPacketAccessRights, IntPtr.Zero);
-        if (status != 0)
+        catch
         {
-            throw new InvalidOperationException($"NtCreateWaitCompletionPacket failed: {status:X8}");
-        }
-
-        timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
-        if (timerHandle.IsInvalid)
-        {
-            throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
+            iocpHandle?.Dispose();
+            waitIocpHandle?.Dispose();
+            timerHandle?.Dispose();
+            throw;
         }
     }
 

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -173,7 +173,9 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
             if (lpCompletionKey != runKey)
             {
-                continue; // Ignore stale packet from a previous run or old cancel events; Cancel packet only used to get out of wait the actual cancel is done via the cts
+                // Ignore stale packet from a previous run or old cancel events; Cancel packet only used to get out of wait the actual cancel is done via the cts
+                // Cancel packets can still be present when the cancel is external and happens after the GetQueuedCompletionStatus call (e.g. while user code is running)
+                continue; 
             }
 
             var currentTicks = stopWatch.ElapsedTicks;

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -96,6 +96,10 @@ internal class QuickTickTimerImplementation : IQuickTickTimer
             {
                 throw new InvalidOperationException($"NtCreateWaitCompletionPacket failed: {status:X8}");
             }
+            if (waitIocpHandle.IsInvalid)
+            {
+                throw new InvalidOperationException("NtCreateWaitCompletionPacket returned success but the handle is invalid.");
+            }
 
             timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
             if (timerHandle.IsInvalid)

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -21,6 +21,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     private long totalSkippedIntervals;
     private readonly Stopwatch stopWatch = new();
 
+    private CancellationTokenSource? cancellationTokenSource;
     private Thread? completionThread;
     private ThreadPriority threadPriority = ThreadPriority.Normal;
     private QuickTickElapsedEventHandler? elapsed;
@@ -97,11 +98,15 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
         SetTimer();
 
-        completionThread = new Thread(CompletionThreadLoop)
+        var cts = new CancellationTokenSource();
+
+        completionThread = new Thread(() => CompletionThreadLoop(cts))
         {
             IsBackground = true,
             Priority = Priority
         };
+
+        cancellationTokenSource = cts;
         completionThread.Start();
     }
 
@@ -113,16 +118,20 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         }
 
         isRunning = false;
+        cancellationTokenSource?.Cancel();
+        cancellationTokenSource?.Dispose();
+
         if (!handles.TimerHandle.IsInvalid)
         {
             Win32Interop.CancelWaitableTimer(handles.TimerHandle);
         }
 
-        // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
-        Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
-
         if (Thread.CurrentThread != completionThread)
         {
+            // Post a dummy completion to get out of GetQueuedCompletionStatusEx in the completionThread. Use a key different to successCompletionKey
+            // If called from the same thread we know we are called from the event handler code therefore we are not waiting on an event and dont need to send a dummy completion
+            Win32Interop.PostQueuedCompletionStatus(handles.IocpHandle, 0, IntPtr.Zero, IntPtr.Zero);
+
             completionThread?.Join();
         }
         completionThread = null;
@@ -170,25 +179,16 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         }
     }
 
-    private void CompletionThreadLoop()
+    private void CompletionThreadLoop(CancellationTokenSource cancellationTokenSource)
     {
-        while (isRunning)
+        while (!cancellationTokenSource.IsCancellationRequested)
         {
             var getStatusResult = Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue);
 
-            if (!getStatusResult)
+            // Check if we were canceled while waiting (External cancel / cancel from other thread). The two secondary checks should not be needed
+            if (cancellationTokenSource.IsCancellationRequested || !getStatusResult || lpCompletionKey != successCompletionKey)
             {
-                if (!Win32Interop.GetHandleInformation(handles.IocpHandle, out _))
-                {
-                    isRunning = false;
-                    break;
-                }
-                continue;
-            }
-
-            if (lpCompletionKey != successCompletionKey)
-            {
-                continue;
+                break;
             }
 
             var currentTicks = stopWatch.ElapsedTicks;

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -9,6 +9,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 {
     private readonly QuickTickHandleResources handles;
     private static readonly IntPtr CancelCompletionKey = IntPtr.Zero;
+    private readonly long ticksPerMillisecond = Stopwatch.Frequency / 1000;
 
     private volatile bool autoReset;
     private volatile bool skipMissedIntervals;
@@ -42,7 +43,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             }
 
             intervalMs = (float)value;
-            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * TimeSpan.TicksPerMillisecond));
+            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * ticksPerMillisecond));
         }
     }
 
@@ -134,24 +135,6 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         }
     }
 
-    public void Dispose()
-    {
-        if (Interlocked.Exchange(ref disposedState, 1) == 1)
-        {
-            return;
-        }
-
-        try
-        {
-            Stop();
-        }
-        finally
-        {
-            elapsed = null;
-            handles.Dispose();
-        }
-    }
-
     private void CompletionThreadLoop(CancellationTokenSource localCancellationTokenSource, IntPtr runKey)
     {
         var stopWatch = Stopwatch.StartNew();
@@ -215,7 +198,8 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
             if (!autoReset)
             {
-                running = false;
+                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
+                localCancellationTokenSource.Cancel();
                 handler?.Invoke(this, elapsedEventArgs);
                 break;
             }
@@ -239,6 +223,24 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         if (status != 0)
         {
             throw new InvalidOperationException($"NtAssociateWaitCompletionPacket failed: {status:X8}");
+        }
+    }
+    
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref disposedState, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            Stop();
+        }
+        finally
+        {
+            handles.Dispose();
+            elapsed = null;
         }
     }
 }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -208,16 +208,18 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 
                 SetTimer(stopWatch, nextFireTicks, runKey);
             }
-            else
-            {
-                running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
-                localCancellationTokenSource.Cancel();
-            }
 
             var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
-
             var handler = elapsed;
+
+            if (!autoReset)
+            {
+                running = false;
+                handler?.Invoke(this, elapsedEventArgs);
+                break;
+            }
+
             handler?.Invoke(this, elapsedEventArgs);
         }
     }

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -70,7 +70,7 @@ public static class QuickTickTiming
         var sleepTimeTicks = -tickToSleep; // negative means relative time
 
         var iocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
-        if (iocpHandle == IntPtr.Zero)
+        if (iocpHandle.IsInvalid)
         {
             throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
         }
@@ -82,7 +82,7 @@ public static class QuickTickTiming
         }
 
         var timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
-        if (timerHandle == IntPtr.Zero)
+        if (timerHandle.IsInvalid)
         {
             throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
         }
@@ -112,19 +112,8 @@ public static class QuickTickTiming
             }
         }
 
-        if (waitIocpHandle != IntPtr.Zero)
-        {
-            Win32Interop.CloseHandle(waitIocpHandle);
-        }
-
-        if (iocpHandle != IntPtr.Zero)
-        {
-            Win32Interop.CloseHandle(iocpHandle);
-        }
-
-        if (timerHandle != IntPtr.Zero)
-        {
-            Win32Interop.CloseHandle(timerHandle);
-        }
+        waitIocpHandle.Dispose();
+        iocpHandle.Dispose();
+        timerHandle.Dispose();
     }
 }

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -5,9 +5,10 @@ namespace QuickTickLib;
 public static class QuickTickTiming
 {
     // Testing showed that waiting 0.5ms results in around 1ms average waiting while going to 0.4ms results in an average of 0.5ms wait time
-    private const long fourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
-    private static readonly IntPtr successCompletionKey = new(1);
+    private const long FourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
+    private static readonly IntPtr SuccessCompletionKey = new(1);
 
+    // ReSharper disable once MemberCanBePrivate.Global
     public static async Task Delay(int millisecondsDelay, CancellationToken cancellationToken = default)
     {
         var isQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
@@ -58,7 +59,7 @@ public static class QuickTickTiming
         var isQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
         if (isQuickTickSupported)
         {       
-            QuickTickSleep(fourHundredMicroSecondInTicks);
+            QuickTickSleep(FourHundredMicroSecondInTicks);
         }
         else
         {
@@ -81,14 +82,14 @@ public static class QuickTickTiming
                 throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
             }
 
-            int ntAssociateWaitCompletionPacketStatus = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, successCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
+            int ntAssociateWaitCompletionPacketStatus = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, SuccessCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
 
             if (ntAssociateWaitCompletionPacketStatus != 0)
             {
                 throw new InvalidOperationException($"NtAssociateWaitCompletionPacket failed: {ntAssociateWaitCompletionPacketStatus:X8}");
             }
 
-            // Checking the return value and the completion key is unnessary since the IOCP is not shared and therefor we expect exactly one completion packet, which is the one we just set up above.
+            // Checking the return value and the completion key is unnecessary since the IOCP is not shared and therefor we expect exactly one completion packet, which is the one we just set up above.
             // The return value would only be false if the IOCP was disposed in which case we also want to stop waiting because that could only happen when the caller disposes the handles or program is shutting down
             Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out _, out _, uint.MaxValue);
         }

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -5,7 +5,8 @@ namespace QuickTickLib;
 public static class QuickTickTiming
 {
     // Testing showed that waiting 0.5ms results in around 1ms average waiting while going to 0.4ms results in an average of 0.5ms wait time
-    const long fourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
+    private const long fourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
+    private static readonly IntPtr successCompletionKey = new(1);
 
     public static async Task Delay(int millisecondsDelay, CancellationToken cancellationToken = default)
     {
@@ -65,55 +66,42 @@ public static class QuickTickTiming
         }
     }
 
-    internal static void QuickTickSleep(long tickToSleep)
+    internal static void QuickTickSleep(long tickToSleep, QuickTickHandleResources? externalHandles = null)
     {
-        var sleepTimeTicks = -tickToSleep; // negative means relative time
+        QuickTickHandleResources? localHandles = null;
 
-        var iocpHandle = Win32Interop.CreateIoCompletionPort(new IntPtr(-1), IntPtr.Zero, IntPtr.Zero, 0);
-        if (iocpHandle.IsInvalid)
+        try
         {
-            throw new InvalidOperationException($"CreateIoCompletionPort failed: {Marshal.GetLastWin32Error()}");
-        }
+            var handles = externalHandles ?? (localHandles = new QuickTickHandleResources());
 
-        var ntCreateWaitCompletionPacketStatus = Win32Interop.NtCreateWaitCompletionPacket(out var waitIocpHandle, QuickTickHelper.NtCreateWaitCompletionPacketAccessRights, IntPtr.Zero);
-        if (ntCreateWaitCompletionPacketStatus != 0)
-        {
-            throw new InvalidOperationException($"NtCreateWaitCompletionPacket failed: {ntCreateWaitCompletionPacketStatus:X8}");
-        }
+            var sleepTimeTicks = -tickToSleep; // negative means relative time
 
-        var timerHandle = Win32Interop.CreateWaitableTimerExW(IntPtr.Zero, IntPtr.Zero, Win32Interop.CreateWaitableTimerFlag_HIGH_RESOLUTION, QuickTickHelper.CreateWaitableTimerExWAccessRights);
-        if (timerHandle.IsInvalid)
-        {
-            throw new InvalidOperationException($"CreateWaitableTimerExW failed: {Marshal.GetLastWin32Error()}");
-        }
-
-        var successCompletionKey = new IntPtr(1);
-
-        if (!Win32Interop.SetWaitableTimer(timerHandle, ref sleepTimeTicks, 0, IntPtr.Zero, IntPtr.Zero, false))
-        {
-            throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
-        }
-
-        int ntAssociateWaitCompletionPacketStatus = Win32Interop.NtAssociateWaitCompletionPacket(waitIocpHandle, iocpHandle, timerHandle, successCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
-
-        if (ntAssociateWaitCompletionPacketStatus != 0)
-        {
-            throw new InvalidOperationException($"NtAssociateWaitCompletionPacket failed: {ntAssociateWaitCompletionPacketStatus:X8}");
-        }
-
-        while (true) // Loop is not strictly neccessary as there should always only be one completion packet.
-        {
-            if (Win32Interop.GetQueuedCompletionStatus(iocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue))
+            if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref sleepTimeTicks, 0, IntPtr.Zero, IntPtr.Zero, false))
             {
-                if (lpCompletionKey == successCompletionKey)
+                throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
+            }
+
+            int ntAssociateWaitCompletionPacketStatus = Win32Interop.NtAssociateWaitCompletionPacket(handles.WaitIocpHandle, handles.IocpHandle, handles.TimerHandle, successCompletionKey, IntPtr.Zero, 0, IntPtr.Zero, out _);
+
+            if (ntAssociateWaitCompletionPacketStatus != 0)
+            {
+                throw new InvalidOperationException($"NtAssociateWaitCompletionPacket failed: {ntAssociateWaitCompletionPacketStatus:X8}");
+            }
+
+            while (true) // Loop is not strictly neccessary as there should always only be one completion packet.
+            {
+                if (Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue))
                 {
-                    break;
+                    if (lpCompletionKey == successCompletionKey)
+                    {
+                        break;
+                    }
                 }
             }
         }
-
-        waitIocpHandle.Dispose();
-        iocpHandle.Dispose();
-        timerHandle.Dispose();
+        finally
+        {
+            localHandles?.Dispose();
+        }
     }
 }

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -74,7 +74,7 @@ public static class QuickTickTiming
         {
             var handles = externalHandles ?? (localHandles = new QuickTickHandleResources());
 
-            var sleepTimeTicks = -tickToSleep; // negative means relative time
+            var sleepTimeTicks = -tickToSleep; // Negative means relative time
 
             if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref sleepTimeTicks, 0, IntPtr.Zero, IntPtr.Zero, false))
             {
@@ -88,16 +88,9 @@ public static class QuickTickTiming
                 throw new InvalidOperationException($"NtAssociateWaitCompletionPacket failed: {ntAssociateWaitCompletionPacketStatus:X8}");
             }
 
-            while (true) // Loop is not strictly neccessary as there should always only be one completion packet.
-            {
-                if (Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out var lpCompletionKey, out _, uint.MaxValue))
-                {
-                    if (lpCompletionKey == successCompletionKey)
-                    {
-                        break;
-                    }
-                }
-            }
+            // Checking the return value and the completion key is unnessary since the IOCP is not shared and therefor we expect exactly one completion packet, which is the one we just set up above.
+            // The return value would only be false if the IOCP was disposed in which case we also want to stop waiting because that could only happen when the caller disposes the handles or program is shutting down
+            Win32Interop.GetQueuedCompletionStatus(handles.IocpHandle, out _, out _, out _, uint.MaxValue);
         }
         finally
         {

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -8,16 +8,19 @@ public static class QuickTickTiming
     private const long FourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
     private static readonly IntPtr SuccessCompletionKey = new(1);
 
+    // Settable in tests (InternalsVisibleTo("QuickTickTests")) to exercise the Thread.Sleep/Task.Delay fallback path
+    internal static bool IsQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
+
     // ReSharper disable once MemberCanBePrivate.Global
     public static async Task Delay(int millisecondsDelay, CancellationToken cancellationToken = default)
     {
-        var isQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
-
-        if (!isQuickTickSupported || millisecondsDelay <= 0)
+        if (!IsQuickTickSupported || millisecondsDelay <= 0)
         {
             await Task.Delay(millisecondsDelay, cancellationToken);
             return;
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         var tcs = new TaskCompletionSource<bool>();
 
@@ -42,9 +45,7 @@ public static class QuickTickTiming
 
     public static void Sleep(int millisecondsTimeout)
     {
-        var isQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
-
-        if (!isQuickTickSupported || millisecondsTimeout <= 0)
+        if (!IsQuickTickSupported || millisecondsTimeout <= 0)
         {
             Thread.Sleep(millisecondsTimeout);
             return;
@@ -56,8 +57,7 @@ public static class QuickTickTiming
 
     internal static void MinimalSleep()
     {
-        var isQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
-        if (isQuickTickSupported)
+        if (IsQuickTickSupported)
         {       
             QuickTickSleep(FourHundredMicroSecondInTicks);
         }

--- a/QuickTickLib/SafeHandles.cs
+++ b/QuickTickLib/SafeHandles.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.InteropServices;
+
+namespace QuickTickLib;
+
+internal sealed class SafeIoCompletionPortHandle : SafeHandle
+{
+    public SafeIoCompletionPortHandle() : base(IntPtr.Zero, true) { }
+
+    public SafeIoCompletionPortHandle(IntPtr handle) : this()
+    {
+        SetHandle(handle);
+    }
+
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle() => Win32Interop.CloseHandle(handle);
+}
+
+internal sealed class SafeTimerHandle : SafeHandle
+{
+    public SafeTimerHandle() : base(IntPtr.Zero, true) { }
+
+    public SafeTimerHandle(IntPtr handle) : this()
+    {
+        SetHandle(handle);
+    }
+
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle() => Win32Interop.CloseHandle(handle);
+}
+
+internal sealed class SafeWaitCompletionPacketHandle : SafeHandle
+{
+    public SafeWaitCompletionPacketHandle() : base(IntPtr.Zero, true) { }
+
+    public SafeWaitCompletionPacketHandle(IntPtr handle) : this()
+    {
+        SetHandle(handle);
+    }
+
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle() => Win32Interop.CloseHandle(handle);
+}

--- a/QuickTickLib/Win32Interop.cs
+++ b/QuickTickLib/Win32Interop.cs
@@ -17,12 +17,12 @@ internal partial class Win32Interop
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool GetHandleInformation(
-        IntPtr hObject,
+        SafeHandle hObject,
         out uint lpdwFlags
     );
 
     [LibraryImport(KernelDll, SetLastError = true)]
-    public static partial IntPtr CreateIoCompletionPort(
+    public static partial SafeIoCompletionPortHandle CreateIoCompletionPort(
         IntPtr FileHandle, // A file handle or Invalid_Handle_Value // Not needed here => use Invalid_Handle_Value
         IntPtr ExistingCompletionPort, // Handle for a open I/O completion port or null // Not needed here
         IntPtr CompletionKey, // Optional CompletionKey to be added to all I/O completion packages related to the file handle // Not needed here
@@ -31,13 +31,13 @@ internal partial class Win32Interop
 
     [LibraryImport(NtDll, SetLastError = true)]
     public static partial int NtCreateWaitCompletionPacket(
-        out IntPtr WaitCompletionPacketHandle, // A pointer to a variable that receives the wait completion packet handle
+        out SafeWaitCompletionPacketHandle WaitCompletionPacketHandle, // A pointer to a variable that receives the wait completion packet handle
         uint DesiredAccess, // Access mask for the wait completion packet
         IntPtr ObjectAttributes // Optional pointer to  PROJECT_ATTRIBUTES // Not needed here
     );
 
     [LibraryImport(KernelDll, SetLastError = true)]
-    public static partial IntPtr CreateWaitableTimerExW(
+    public static partial SafeTimerHandle CreateWaitableTimerExW(
         IntPtr lpTimerAttributes,  // Optional pointer to a SECURITY_ATTRIBUTES structure // Not needed here
         IntPtr lpTimerName, // Optional pinter to the name of the timer // Not needed here
         uint dwFlags, // Flags for the timer
@@ -46,9 +46,9 @@ internal partial class Win32Interop
 
     [LibraryImport(NtDll, SetLastError = true)]
     public static partial int NtAssociateWaitCompletionPacket(
-        IntPtr WaitCompletionPacketHandle, // Handle to a wait completion package
-        IntPtr IoCompletionHandle, // Handle to the I/O completion port
-        IntPtr TargetObjectHandle, // A handle to a waitable object // Here the timer
+        SafeWaitCompletionPacketHandle WaitCompletionPacketHandle, // Handle to a wait completion package
+        SafeIoCompletionPortHandle IoCompletionHandle, // Handle to the I/O completion port
+        SafeHandle TargetObjectHandle, // A handle to a waitable object // Here the timer
         IntPtr KeyContext, // Optional key context // Not needed here 
         IntPtr ApcContext, // Optional apc context // Not needed here
         int IoStatus, // Status that would be returned on call to NtRemoveIoCompletion
@@ -59,7 +59,7 @@ internal partial class Win32Interop
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool SetWaitableTimer(
-        IntPtr hTimer, // Pointer to the timer
+        SafeTimerHandle hTimer, // Pointer to the timer
         ref long lpDueTime, // Due time of the timer. Positive values are absolute timestamps while negative values are a reference to the current time (In 100ns steps)
         int lPeriod, // If bigger then 0 the timer will be signaled multiple times // Seems to be less precise so we just keep reseeting the timer instead
         IntPtr pfnCompletionRoutine, // Optional pointer to a completion routine // Not needed here as we use the I/O completion package instead 
@@ -70,13 +70,13 @@ internal partial class Win32Interop
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool CancelWaitableTimer(
-        IntPtr hTimer // Handle of the timer to cancel
+        SafeTimerHandle hTimer // Handle of the timer to cancel
     );
 
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool GetQueuedCompletionStatus(
-        IntPtr completionPort, // Handle to the I/O completion port
+        SafeIoCompletionPortHandle completionPort, // Handle to the I/O completion port
         out uint lpNumberOfBytesTransferred, // Number of bytes transferred in the I/O completion operation.
         out IntPtr lpCompletionKey, // Pointer to the completionKey
         out IntPtr lpOverlapped, // Pointer to a OVERLAPPED structure that was specified when the completed I/O operation was started.
@@ -86,7 +86,7 @@ internal partial class Win32Interop
     [LibraryImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool PostQueuedCompletionStatus(
-        IntPtr completionPort, // Handle to the I/O completion port
+        SafeIoCompletionPortHandle completionPort, // Handle to the I/O completion port
         uint numberOfBytesTransferred, // Value that is returned as lpNumberOfBytesTransferred on GetQueuedCompletionStatus
         IntPtr completionKey, // Value thats returned as lpCompletionKey on GetQueuedCompletionStatus
         IntPtr lpOverlapped // Value thats returned as lpOverlapped on GetQueuedCompletionStatus
@@ -94,7 +94,7 @@ internal partial class Win32Interop
 
     [LibraryImport(NtDll, SetLastError = true)]
     public static partial int NtCancelWaitCompletionPacket(
-        IntPtr WaitCompletionPacketHandle, // Handle to a wait completion package
+        SafeWaitCompletionPacketHandle WaitCompletionPacketHandle, // Handle to a wait completion package
         [MarshalAs(UnmanagedType.Bool)] bool RemoveSignaledPacket // Whether to attempt to cancel a packet from IO completion object queue.
     );
 #else
@@ -107,12 +107,12 @@ internal partial class Win32Interop
     [DllImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetHandleInformation(
-        IntPtr hObject, 
+        SafeHandle hObject, 
         out uint lpdwFlags
     );
 
     [DllImport(KernelDll, SetLastError = true)]
-    public static extern IntPtr CreateIoCompletionPort(
+    public static extern SafeIoCompletionPortHandle CreateIoCompletionPort(
         IntPtr FileHandle, // A file handle or INVALID_HANDLE_VALUE
         IntPtr ExistingCompletionPort, // Handle for an open I/O completion port or null
         IntPtr CompletionKey, // Optional CompletionKey for I/O completion packages
@@ -121,13 +121,13 @@ internal partial class Win32Interop
 
     [DllImport(NtDll, SetLastError = true)]
     public static extern int NtCreateWaitCompletionPacket(
-        out IntPtr WaitCompletionPacketHandle, // Receives the wait completion packet handle
+        out SafeWaitCompletionPacketHandle WaitCompletionPacketHandle, // Receives the wait completion packet handle
         uint DesiredAccess, // Access mask for the wait completion packet
         IntPtr ObjectAttributes // Optional pointer to OBJECT_ATTRIBUTES
     );
 
     [DllImport(KernelDll, SetLastError = true, CharSet = CharSet.Unicode)]
-    public static extern IntPtr CreateWaitableTimerExW(
+    public static extern SafeTimerHandle CreateWaitableTimerExW(
         IntPtr lpTimerAttributes, // Optional pointer to a SECURITY_ATTRIBUTES structure
         IntPtr lpTimerName, // Optional pointer to the name of the timer
         uint dwFlags, // Flags for the timer
@@ -136,9 +136,9 @@ internal partial class Win32Interop
 
     [DllImport(NtDll, SetLastError = true)]
     public static extern int NtAssociateWaitCompletionPacket(
-        IntPtr WaitCompletionPacketHandle, // Handle to a wait completion packet
-        IntPtr IoCompletionHandle, // Handle to the I/O completion port
-        IntPtr TargetObjectHandle, // A handle to a waitable object (e.g., timer)
+        SafeWaitCompletionPacketHandle WaitCompletionPacketHandle, // Handle to a wait completion packet
+        SafeIoCompletionPortHandle IoCompletionHandle, // Handle to the I/O completion port
+        SafeHandle TargetObjectHandle, // A handle to a waitable object (e.g., timer)
         IntPtr KeyContext, // Optional key context
         IntPtr ApcContext, // Optional APC context
         int IoStatus, // Status for NtRemoveIoCompletion
@@ -149,7 +149,7 @@ internal partial class Win32Interop
     [DllImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool SetWaitableTimer(
-        IntPtr hTimer, // Pointer to the timer
+        SafeTimerHandle hTimer, // Pointer to the timer
         ref long lpDueTime, // Due time (absolute or relative in 100ns steps)
         int lPeriod, // Period for recurring timer, 0 for one-shot
         IntPtr pfnCompletionRoutine, // Optional completion routine
@@ -160,13 +160,13 @@ internal partial class Win32Interop
     [DllImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool CancelWaitableTimer(
-        IntPtr hTimer // Handle of the timer to cancel
+        SafeTimerHandle hTimer // Handle of the timer to cancel
     );
 
     [DllImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetQueuedCompletionStatus(
-        IntPtr completionPort, // Handle to the I/O completion port
+        SafeIoCompletionPortHandle completionPort, // Handle to the I/O completion port
         out uint lpNumberOfBytesTransferred, // Bytes transferred in I/O operation
         out IntPtr lpCompletionKey, // Pointer to the completion key
         out IntPtr lpOverlapped, // Pointer to OVERLAPPED structure
@@ -176,7 +176,7 @@ internal partial class Win32Interop
     [DllImport(KernelDll, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool PostQueuedCompletionStatus(
-        IntPtr completionPort, // Handle to the I/O completion port
+        SafeIoCompletionPortHandle completionPort, // Handle to the I/O completion port
         uint numberOfBytesTransferred, // Value for lpNumberOfBytesTransferred
         IntPtr completionKey, // Value for lpCompletionKey
         IntPtr lpOverlapped // Value for lpOverlapped
@@ -184,7 +184,7 @@ internal partial class Win32Interop
 
     [DllImport(NtDll, SetLastError = true)]
     public static extern int NtCancelWaitCompletionPacket(
-        IntPtr WaitCompletionPacketHandle, // Handle to a wait completion packet
+        SafeWaitCompletionPacketHandle WaitCompletionPacketHandle, // Handle to a wait completion packet
         [MarshalAs(UnmanagedType.Bool)] bool RemoveSignaledPacket // Whether to cancel a packet from the IO completion queue
     );
 

--- a/QuickTickLib/Win32Interop.cs
+++ b/QuickTickLib/Win32Interop.cs
@@ -15,13 +15,6 @@ internal partial class Win32Interop
     );
 
     [LibraryImport(KernelDll, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool GetHandleInformation(
-        SafeHandle hObject,
-        out uint lpdwFlags
-    );
-
-    [LibraryImport(KernelDll, SetLastError = true)]
     public static partial SafeIoCompletionPortHandle CreateIoCompletionPort(
         IntPtr FileHandle, // A file handle or Invalid_Handle_Value // Not needed here => use Invalid_Handle_Value
         IntPtr ExistingCompletionPort, // Handle for a open I/O completion port or null // Not needed here
@@ -103,13 +96,6 @@ internal partial class Win32Interop
     public static extern bool CloseHandle(
           IntPtr hObject // The handle to close
       );
-
-    [DllImport(KernelDll, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool GetHandleInformation(
-        SafeHandle hObject, 
-        out uint lpdwFlags
-    );
 
     [DllImport(KernelDll, SetLastError = true)]
     public static extern SafeIoCompletionPortHandle CreateIoCompletionPort(

--- a/QuickTickTests/QuickTickTests.csproj
+++ b/QuickTickTests/QuickTickTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QuickTickLib\QuickTickLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/QuickTickTests/QuickTickTests.csproj
+++ b/QuickTickTests/QuickTickTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/QuickTickTests/QuickTickTimingTests.cs
+++ b/QuickTickTests/QuickTickTimingTests.cs
@@ -57,9 +57,10 @@ public class QuickTickTimingTests
     {
         using var cts = new CancellationTokenSource();
         cts.Cancel();
+        var token = cts.Token;
 
         var sw = Stopwatch.StartNew();
-        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, token));
         sw.Stop();
         Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(200.0), "Should cancel immediately, not run the full 5 s delay");
     }
@@ -69,9 +70,10 @@ public class QuickTickTimingTests
     {
         using var cts = new CancellationTokenSource();
         cts.Cancel();
+        var token = cts.Token;
 
         var sw = Stopwatch.StartNew();
-        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(0, cts.Token));
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(0, token));
         sw.Stop();
         Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(200.0));
     }
@@ -81,9 +83,10 @@ public class QuickTickTimingTests
     {
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(50);
+        var token = cts.Token;
 
         var sw = Stopwatch.StartNew();
-        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, token));
         sw.Stop();
         Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 200.0), "Should cancel after ~50 ms, not run the full 5 s delay");
     }
@@ -94,13 +97,11 @@ public class QuickTickTimingTests
 [NonParallelizable]
 public class QuickTickTimingFallbackPathTests
 {
-    private static readonly bool OriginalValue = QuickTickTiming.IsQuickTickSupported;
-
     [SetUp]
     public void SetUp() => QuickTickTiming.IsQuickTickSupported = false;
 
     [TearDown]
-    public void TearDown() => QuickTickTiming.IsQuickTickSupported = OriginalValue;
+    public void TearDown() => QuickTickTiming.IsQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
 
     [Test]
     public void Sleep_PositiveDuration_FallsBackToThreadSleep()
@@ -134,9 +135,10 @@ public class QuickTickTimingFallbackPathTests
     {
         using var cts = new CancellationTokenSource();
         cts.Cancel();
+        var token = cts.Token;
 
         var sw = Stopwatch.StartNew();
-        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, token));
         sw.Stop();
         Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(200.0));
     }
@@ -146,9 +148,10 @@ public class QuickTickTimingFallbackPathTests
     {
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(50);
+        var token = cts.Token;
 
         var sw = Stopwatch.StartNew();
-        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, token));
         sw.Stop();
         Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 200.0));
     }

--- a/QuickTickTests/QuickTickTimingTests.cs
+++ b/QuickTickTests/QuickTickTimingTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+using NUnit.Framework;
+using QuickTickLib;
+
+namespace QuickTickTests;
+
+[Platform(Include = "Win", Reason = "Timer implementations rely on Win32 APIs or Windows timing behavior")]
+public class QuickTickTimingTests
+{
+    [Test]
+    public void Sleep_PositiveDuration_SleepsApproximatelyCorrectTime()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Sleep(50);
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 100.0));
+    }
+
+    [Test]
+    public void Sleep_ZeroDuration_ReturnsImmediately()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Sleep(0);
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(20.0));
+    }
+
+    [Test]
+    public void Delay_PositiveDuration_CompletesApproximatelyOnTime()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Delay(50).GetAwaiter().GetResult();
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 100.0));
+    }
+
+    [Test]
+    public void Delay_ZeroDuration_CompletesImmediately()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Delay(0).GetAwaiter().GetResult();
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(20.0));
+    }
+
+    [Test]
+    public void Delay_TimeSpanOverload_CompletesApproximatelyOnTime()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Delay(TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 100.0));
+    }
+
+    [Test]
+    public void Delay_PreCancelledToken_PositiveDuration_ThrowsImmediately()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sw = Stopwatch.StartNew();
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(200.0), "Should cancel immediately, not run the full 5 s delay");
+    }
+
+    [Test]
+    public void Delay_PreCancelledToken_ZeroDuration_ThrowsImmediately()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sw = Stopwatch.StartNew();
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(0, cts.Token));
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(200.0));
+    }
+
+    [Test]
+    public void Delay_TokenCancelledDuringWait_ThrowsWhenCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(50);
+
+        var sw = Stopwatch.StartNew();
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 200.0), "Should cancel after ~50 ms, not run the full 5 s delay");
+    }
+}
+
+// Tests that exercise the Thread.Sleep / Task.Delay fallback path by replacing the platform check delegate.
+// Marked NonParallelizable because they mutate a static field on QuickTickTiming.
+[NonParallelizable]
+public class QuickTickTimingFallbackPathTests
+{
+    private static readonly bool OriginalValue = QuickTickTiming.IsQuickTickSupported;
+
+    [SetUp]
+    public void SetUp() => QuickTickTiming.IsQuickTickSupported = false;
+
+    [TearDown]
+    public void TearDown() => QuickTickTiming.IsQuickTickSupported = OriginalValue;
+
+    [Test]
+    public void Sleep_PositiveDuration_FallsBackToThreadSleep()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Sleep(50);
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 150.0));
+    }
+
+    [Test]
+    public void Delay_PositiveDuration_FallsBackToTaskDelay()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Delay(50).GetAwaiter().GetResult();
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 150.0));
+    }
+
+    [Test]
+    public void Delay_TimeSpanOverload_FallsBackToTaskDelay()
+    {
+        var sw = Stopwatch.StartNew();
+        QuickTickTiming.Delay(TimeSpan.FromMilliseconds(50)).GetAwaiter().GetResult();
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 150.0));
+    }
+
+    [Test]
+    public void Delay_PreCancelledToken_ThrowsImmediately()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sw = Stopwatch.StartNew();
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(200.0));
+    }
+
+    [Test]
+    public void Delay_TokenCancelledDuringWait_ThrowsWhenCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(50);
+
+        var sw = Stopwatch.StartNew();
+        Assert.CatchAsync<OperationCanceledException>(() => QuickTickTiming.Delay(5000, cts.Token));
+        sw.Stop();
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.InRange(30.0, 200.0));
+    }
+}

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -64,9 +64,7 @@ public class TimerBehaviorTests
         Thread.Sleep(500); // Extra time for any rogue second fire
         Assert.That(count, Is.EqualTo(1));
     }
-
-    // --- Stop / Start lifecycle ---
-
+    
     [TestCaseSource(nameof(AllTimerKinds))]
     public void Stop_PreventsSubsequentFires(string kind)
     {

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -207,7 +207,6 @@ public class TimerBehaviorTests
         using var timer = CreateTimer(kind);
         var skips = new ConcurrentQueue<long>();
         var inFirstRun = new[] { true }; 
-        var secondRunFired = new ManualResetEventSlim(false);
 
         timer.Elapsed += (_, args) =>
         {
@@ -215,10 +214,6 @@ public class TimerBehaviorTests
             if (inFirstRun[0])
             {
                 Thread.Sleep(30); // Accumulate skips during the first run
-            }
-            else
-            {
-                secondRunFired.Set();
             }
         };
         timer.SkipMissedIntervals = true;

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -1,0 +1,207 @@
+using System.Collections.Concurrent;
+using NUnit.Framework;
+using QuickTickLib;
+
+namespace QuickTickTests;
+
+// Tests run against all three timer implementations to verify they behave consistently.
+// These tests should verify function not performance
+[Platform(Include = "Win", Reason = "Timer implementations rely on Win32 APIs or Windows timing behavior")]
+public class TimerBehaviorTests
+{
+    private const double IntervalMs = 15.625; // Use default timing of windows so tests are mostly predictable even with fallback timer
+
+    private static IEnumerable<string> AllTimerKinds() =>
+    [
+        "implementation",
+        "fallback",
+        "highResolution",
+    ];
+
+    private static IQuickTickTimer CreateTimer(string kind, double intervalMs = IntervalMs) => kind switch
+    {
+        "implementation" => new QuickTickTimerImplementation(intervalMs),
+        "fallback"       => new QuickTickTimerFallback(intervalMs),
+        "highResolution" => new HighResQuickTickTimer(intervalMs),
+        _                => throw new ArgumentException($"Unknown timer kind: {kind}", nameof(kind))
+    };
+    
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Basic_Timer_Creation(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var fired = new ManualResetEventSlim(false);
+        timer.Elapsed += (_, _) => fired.Set();
+        timer.Start();
+        Assert.That(fired.Wait(TimeSpan.FromMilliseconds(200)), Is.True, $"{kind}: timer did not fire within 200 ms");
+        timer.Stop();
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void AutoReset_FiresMultipleTimes(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.Elapsed += (_, _) => count++;
+        timer.AutoReset = true;
+        timer.Start();
+        Thread.Sleep(500); // ~32 fires expected at 20 ms
+        timer.Stop();
+        Assert.That(count, Is.InRange(22, 42));
+    }
+    
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void AutoResetFalse_FiresExactlyOnce(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.Elapsed += (_, _) => count++;
+        timer.AutoReset = false;
+        timer.Start();
+        Thread.Sleep(500); // Extra time for any rogue second fire
+        Assert.That(count, Is.EqualTo(1));
+    }
+
+    // --- Stop / Start lifecycle ---
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Stop_PreventsSubsequentFires(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        var firstFired = new ManualResetEventSlim(false);
+        timer.Elapsed += (_, _) => { count++; firstFired.Set(); };
+        timer.Start();
+        Assert.That(firstFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True);
+        timer.Stop();
+        Thread.Sleep(150); // Give extra time for additional fires that shouldn't happen
+        Assert.That(count, Is.EqualTo(1));
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void MultipleStops_DoNotThrow(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        timer.Start();
+        timer.Stop();
+        timer.Stop();
+        timer.Stop();
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void MultipleStarts_AreIgnored(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.Elapsed += (_, _) => count++;
+        timer.Start();
+        timer.Start();
+        timer.Start();
+        Thread.Sleep(500);
+        timer.Stop();
+        Assert.That(count, Is.InRange(22, 42)); // One timer should run only still expect ~32 fires
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void StartAfterStop_FiresAgain(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.Elapsed += (_, _) => count++;
+
+        timer.Start();
+        Thread.Sleep(100);
+        timer.Stop();
+        var countFirstRun = count;
+        Assert.That(countFirstRun, Is.GreaterThan(0), $"{kind}: expected fires during first run");
+
+        timer.Start();
+        Thread.Sleep(100);
+        timer.Stop();
+        Assert.That(count, Is.GreaterThan(countFirstRun), $"{kind}: expected fires during second run");
+    }
+    
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void StopFromHandler_DoesNotDeadlock(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var done = new ManualResetEventSlim(false);
+        timer.Elapsed += (_, _) =>
+        {
+            // ReSharper disable once AccessToDisposedClosure
+            timer.Stop();
+            done.Set();
+        };
+        timer.Start();
+        Assert.That(done.Wait(TimeSpan.FromMilliseconds(200)), Is.True, $"{kind}: Stop() from handler deadlocked or timed out");
+    }
+    
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Dispose_StopsTimer(string kind)
+    {
+        var timer = CreateTimer(kind);
+        var count = 0;
+        var firstFired = new ManualResetEventSlim(false);
+        timer.Elapsed += (_, _) => { count++; firstFired.Set(); };
+        timer.Start();
+        Assert.That(firstFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True);
+        timer.Dispose();
+        var countAtDispose = count;
+        Thread.Sleep(150);
+        Assert.That(count, Is.EqualTo(countAtDispose));
+    }
+    
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void SkipMissedIntervals_ReportsSkippedCount(string kind)
+    {
+        using var timer = CreateTimer(kind, intervalMs: 10);
+        var skippedCounts = new ConcurrentBag<long>();
+        timer.Elapsed += (_, args) =>
+        {
+            skippedCounts.Add(args.SkippedIntervals);
+            Thread.Sleep(50); // Deliberately blocking event code so the timer has to skip ticks
+        };
+        timer.SkipMissedIntervals = true;
+        timer.Start();
+        Thread.Sleep(250);
+        timer.Stop();
+        Assert.That(skippedCounts, Has.Some.GreaterThan(0L));
+    }
+
+    //Rework this to only block first call then check the timing since last tick;
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void SkipMissedIntervalsDisabled_DoesNotSkip(string kind)
+    {
+        using var timer = CreateTimer(kind, intervalMs: 10);
+        var skippedCounts = new ConcurrentBag<long>();
+        timer.Elapsed += (_, args) =>
+        {
+            skippedCounts.Add(args.SkippedIntervals);
+            Thread.Sleep(50); // Slow handler — but skipping is off
+        };
+        timer.SkipMissedIntervals = false;
+        timer.Start();
+        Thread.Sleep(600);
+        timer.Stop();
+        Assert.That(skippedCounts, Is.All.EqualTo(0L));
+    }
+
+    // --- ElapsedEventArgs sanity ---
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void ElapsedArgs_TimeSinceLastInterval_IsPositive(string kind)
+    {
+        using var timer = CreateTimer(kind, intervalMs: 20);
+        var timings = new ConcurrentBag<double>();
+        timer.Elapsed += (_, args) => timings.Add(args.TimeSinceLastInterval.TotalMilliseconds);
+        timer.Start();
+        Thread.Sleep(400);
+        timer.Stop();
+
+        var recorded = timings.ToArray();
+        Assert.That(recorded, Is.Not.Empty);
+        // First fire has lastFireTicks=0 so value equals time-since-start (~20 ms).
+        // Subsequent fires should be ~20 ms. Allow a wide ceiling for jitter.
+        Assert.That(recorded, Is.All.InRange(0.0, 500.0));
+    }
+}

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -181,17 +181,68 @@ public class TimerBehaviorTests
     public void SkipMissedIntervals_ReportsSkippedCount(string kind)
     {
         using var timer = CreateTimer(kind);
-        var skippedCounts = new ConcurrentBag<long>();
+        var history = new ConcurrentQueue<long>();
         timer.Elapsed += (_, args) =>
         {
-            skippedCounts.Add(args.SkippedIntervals);
-            Thread.Sleep(50); // Deliberately blocking event code so the timer has to skip ticks
+            history.Enqueue(args.SkippedIntervals);
+            Thread.Sleep(50);
         };
         timer.SkipMissedIntervals = true;
         timer.Start();
-        Thread.Sleep(250);
+        Thread.Sleep(400);
         timer.Stop();
-        Assert.That(skippedCounts, Has.Some.GreaterThan(0L));
+
+        var values = history.ToArray();
+        
+        Assert.That(values, Has.Some.GreaterThan(0L), "skipped count should grow above zero");
+        for (var i = 1; i < values.Length; i++)
+        {
+            Assert.That(values[i], Is.GreaterThanOrEqualTo(values[i - 1]), $"SkippedIntervals decreased at tick {i - 1}→{i} ({values[i - 1]}→{values[i]})");
+        }
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void SkipMissedIntervals_ResetsToZeroOnRestart(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var skips = new ConcurrentQueue<long>();
+        var inFirstRun = new[] { true }; 
+        var secondRunFired = new ManualResetEventSlim(false);
+
+        timer.Elapsed += (_, args) =>
+        {
+            skips.Enqueue(args.SkippedIntervals);
+            if (inFirstRun[0])
+            {
+                Thread.Sleep(30); // Accumulate skips during the first run
+            }
+            else
+            {
+                secondRunFired.Set();
+            }
+        };
+        timer.SkipMissedIntervals = true;
+
+        timer.Start();
+        Thread.Sleep(200);
+        timer.Stop();
+        
+        Assert.That(skips, Has.Some.GreaterThan(0L), "skipped count should grow above zero");
+        
+        while (skips.Any())
+        {
+            skips.TryDequeue(out _);
+        }
+        
+        inFirstRun[0] = false;
+        
+        timer.Start();
+        Thread.Sleep(200);
+        timer.Stop();
+
+        Assert.That(skips, Has.Count.GreaterThan(0L));
+        skips.TryDequeue(out var firstSkipAfterRestart);
+        Assert.That(firstSkipAfterRestart, Is.EqualTo(0L), $"{kind}: SkippedIntervals should reset to 0 after Stop()+Start()");
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using NUnit.Framework;
 using QuickTickLib;
 
@@ -9,7 +10,9 @@ namespace QuickTickTests;
 [Platform(Include = "Win", Reason = "Timer implementations rely on Win32 APIs or Windows timing behavior")]
 public class TimerBehaviorTests
 {
-    private const double IntervalMs = 15.625; // Use default timing of windows so tests are mostly predictable even with fallback timer
+    // Use default timing of windows (15.625) so tests are mostly predictable even with fallback timer
+    // Actually stay just below the default for windows because using it exactly can lead to the fallback timer waiting double very often
+    private const double IntervalMs = 15; 
 
     private static IEnumerable<string> AllTimerKinds() =>
     [
@@ -18,11 +21,11 @@ public class TimerBehaviorTests
         "highResolution",
     ];
 
-    private static IQuickTickTimer CreateTimer(string kind, double intervalMs = IntervalMs) => kind switch
+    private static IQuickTickTimer CreateTimer(string kind) => kind switch
     {
-        "implementation" => new QuickTickTimerImplementation(intervalMs),
-        "fallback"       => new QuickTickTimerFallback(intervalMs),
-        "highResolution" => new HighResQuickTickTimer(intervalMs),
+        "implementation" => new QuickTickTimerImplementation(IntervalMs),
+        "fallback"       => new QuickTickTimerFallback(IntervalMs),
+        "highResolution" => new HighResQuickTickTimer(IntervalMs),
         _                => throw new ArgumentException($"Unknown timer kind: {kind}", nameof(kind))
     };
     
@@ -47,7 +50,7 @@ public class TimerBehaviorTests
         timer.Start();
         Thread.Sleep(500); // ~32 fires expected at 20 ms
         timer.Stop();
-        Assert.That(count, Is.InRange(22, 42));
+        Assert.That(count, Is.InRange(14, 37));
     }
     
     [TestCaseSource(nameof(AllTimerKinds))]
@@ -94,12 +97,27 @@ public class TimerBehaviorTests
         using var timer = CreateTimer(kind);
         var count = 0;
         timer.Elapsed += (_, _) => count++;
+
+        var proc = Process.GetCurrentProcess();
+        proc.Refresh();
+        var threadsBefore = proc.Threads.Count;
+
         timer.Start();
         timer.Start();
         timer.Start();
-        Thread.Sleep(500);
+        timer.Start();
+        timer.Start();
+
+        Thread.Sleep(50); // Let spawned threads settle before counting
+        proc.Refresh();
+        var threadsAfterMultipleStarts = proc.Threads.Count;
+
+        Thread.Sleep(450); // Run for total ~500ms
         timer.Stop();
-        Assert.That(count, Is.InRange(22, 42)); // One timer should run only still expect ~32 fires
+
+        Assert.That(count, Is.InRange(14, 37)); // One timer should run only, still expect ~32 fires
+
+        Assert.That(threadsAfterMultipleStarts - threadsBefore, Is.LessThanOrEqualTo(2), $"{kind}: multiple Start() calls spawned more than 1 new thread");
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]
@@ -154,7 +172,7 @@ public class TimerBehaviorTests
     [TestCaseSource(nameof(AllTimerKinds))]
     public void SkipMissedIntervals_ReportsSkippedCount(string kind)
     {
-        using var timer = CreateTimer(kind, intervalMs: 10);
+        using var timer = CreateTimer(kind);
         var skippedCounts = new ConcurrentBag<long>();
         timer.Elapsed += (_, args) =>
         {
@@ -168,30 +186,43 @@ public class TimerBehaviorTests
         Assert.That(skippedCounts, Has.Some.GreaterThan(0L));
     }
 
-    //Rework this to only block first call then check the timing since last tick;
     [TestCaseSource(nameof(AllTimerKinds))]
-    public void SkipMissedIntervalsDisabled_DoesNotSkip(string kind)
+    public void SkipMissedIntervalsDisabled_CatchesUpMissedTicks(string kind)
     {
-        using var timer = CreateTimer(kind, intervalMs: 10);
-        var skippedCounts = new ConcurrentBag<long>();
+        using var timer = CreateTimer(kind);
+        var timings = new ConcurrentQueue<double>();
+        var firstCall = true;
+
         timer.Elapsed += (_, args) =>
         {
-            skippedCounts.Add(args.SkippedIntervals);
-            Thread.Sleep(50); // Slow handler — but skipping is off
+            timings.Enqueue(args.TimeSinceLastInterval.TotalMilliseconds);
+            if (firstCall)
+            {
+                firstCall = false;
+                Thread.Sleep(100); // Block only the first call: Make some timer fires que up
+            }
         };
         timer.SkipMissedIntervals = false;
         timer.Start();
-        Thread.Sleep(600);
+        Thread.Sleep(400);
         timer.Stop();
-        Assert.That(skippedCounts, Is.All.EqualTo(0L));
+        
+        Assert.That(timings, Has.Count.GreaterThan(10));
+
+        timings.TryDequeue(out var firstTime);
+        timings.TryDequeue(out var secondTime);
+        timings.TryDequeue(out var thirdTime);
+        timings.TryDequeue(out var forthTime);
+        Assert.That(firstTime, Is.InRange(10.0, 35.0));
+        Assert.That(secondTime, Is.InRange(70.0, 140.0));
+        Assert.That(thirdTime, Is.InRange(0.0, 5.0));
+        Assert.That(forthTime, Is.InRange(0.0, 5.0));
     }
-
-    // --- ElapsedEventArgs sanity ---
-
+    
     [TestCaseSource(nameof(AllTimerKinds))]
-    public void ElapsedArgs_TimeSinceLastInterval_IsPositive(string kind)
+    public void ElapsedArgs_TimeSinceLastInterval_IsValid(string kind)
     {
-        using var timer = CreateTimer(kind, intervalMs: 20);
+        using var timer = CreateTimer(kind);
         var timings = new ConcurrentBag<double>();
         timer.Elapsed += (_, args) => timings.Add(args.TimeSinceLastInterval.TotalMilliseconds);
         timer.Start();
@@ -200,8 +231,6 @@ public class TimerBehaviorTests
 
         var recorded = timings.ToArray();
         Assert.That(recorded, Is.Not.Empty);
-        // First fire has lastFireTicks=0 so value equals time-since-start (~20 ms).
-        // Subsequent fires should be ~20 ms. Allow a wide ceiling for jitter.
-        Assert.That(recorded, Is.All.InRange(0.0, 500.0));
+        Assert.That(recorded, Is.All.InRange(10.0, 37.0));
     }
 }

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -306,6 +306,27 @@ public class TimerBehaviorTests
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]
+    public void Stop_BlocksUntilCurrentHandlerCompletes(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var handlerStarted  = new ManualResetEventSlim(false);
+        var handlerFinished = new ManualResetEventSlim(false);
+
+        timer.Elapsed += (_, _) =>
+        {
+            handlerStarted.Set();
+            Thread.Sleep(150);
+            handlerFinished.Set();
+        };
+
+        timer.Start();
+        Assert.That(handlerStarted.Wait(TimeSpan.FromMilliseconds(500)), Is.True, "handler should start within 500 ms");
+
+        timer.Stop();
+        Assert.That(handlerFinished.IsSet, Is.True, $"{kind}: Stop() must block until the handler completes (thread join)");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
     public void ElapsedArgs_TimeSinceLastInterval_IsValid(string kind)
     {
         using var timer = CreateTimer(kind);

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -117,7 +117,7 @@ public class TimerBehaviorTests
 
         Assert.That(count, Is.InRange(14, 37)); // One timer should run only, still expect ~32 fires
 
-        Assert.That(threadsAfterMultipleStarts - threadsBefore, Is.LessThanOrEqualTo(2), $"{kind}: multiple Start() calls spawned more than 1 new thread");
+        Assert.That(threadsAfterMultipleStarts - threadsBefore, Is.LessThanOrEqualTo(1), $"{kind}: multiple Start() calls spawned more than 1 new thread");
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]
@@ -157,6 +157,10 @@ public class TimerBehaviorTests
     [TestCaseSource(nameof(AllTimerKinds))]
     public void Dispose_StopsTimer(string kind)
     {
+        var proc = Process.GetCurrentProcess();
+        proc.Refresh();
+        var threadsBeforeTimerCreation = proc.Threads.Count;
+        
         var timer = CreateTimer(kind);
         var count = 0;
         var firstFired = new ManualResetEventSlim(false);
@@ -167,6 +171,10 @@ public class TimerBehaviorTests
         var countAtDispose = count;
         Thread.Sleep(150);
         Assert.That(count, Is.EqualTo(countAtDispose));
+        
+        proc.Refresh();
+        var threadsAfterDispose = proc.Threads.Count;
+        Assert.That(threadsAfterDispose - threadsBeforeTimerCreation, Is.Zero, $"{kind}: Creating and disposing a timer left a ghost thread");
     }
     
     [TestCaseSource(nameof(AllTimerKinds))]

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -279,6 +279,33 @@ public class TimerBehaviorTests
     }
     
     [TestCaseSource(nameof(AllTimerKinds))]
+    public void AutoResetFalse_StartFromHandler_RestartsTimer(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var fireCount = 0;
+        var secondFired = new ManualResetEventSlim(false);
+
+        timer.AutoReset = false;
+        timer.Elapsed += (_, _) =>
+        {
+            fireCount++;
+            if (fireCount == 1)
+            {
+                // ReSharper disable once AccessToDisposedClosure
+                timer.Start();
+            }
+            else
+            {
+                secondFired.Set();
+            }
+        };
+
+        timer.Start();
+        Assert.That(secondFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True, $"{kind}: Start() from AutoReset=false handler should restart the timer");
+        timer.Stop();
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
     public void ElapsedArgs_TimeSinceLastInterval_IsValid(string kind)
     {
         using var timer = CreateTimer(kind);

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -239,6 +239,45 @@ public class TimerBehaviorTests
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]
+    public void SkipMissedIntervals_StopWhileLongHandlerRunning_SkippedCountResetsOnRestart(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var skips = new ConcurrentQueue<long>();
+        var handlerStarted = new ManualResetEventSlim(false);
+        var firstCall = true;
+
+        timer.AutoReset = true;
+        timer.SkipMissedIntervals = true;
+        timer.Elapsed += (_, args) =>
+        {
+            skips.Enqueue(args.SkippedIntervals);
+            if (firstCall)
+            {
+                firstCall = false;
+                handlerStarted.Set();
+                Thread.Sleep(150); // Stay blocked so intervals pile up AND Stop() is called while we're here
+            }
+        };
+
+        timer.Start();
+        Assert.That(handlerStarted.Wait(TimeSpan.FromMilliseconds(500)), Is.True);
+
+        Thread.Sleep(50); // Let more intervals pile up while handler is blocked (~3 extra at 15ms interval)
+        timer.Stop(); // Stop() is called while the handler is still sleeping; it blocks here until handler returns
+
+        while (skips.Any()) skips.TryDequeue(out _);
+
+        // Restart — accumulated/piled-up events must not carry the skipped count into the new run
+        timer.Start();
+        Thread.Sleep(200);
+        timer.Stop();
+
+        Assert.That(skips, Has.Count.GreaterThan(0), $"{kind}: expected ticks after restart");
+        skips.TryDequeue(out var firstSkipAfterRestart);
+        Assert.That(firstSkipAfterRestart, Is.EqualTo(0L), $"{kind}: SkippedIntervals must reset to 0 after Stop()+Start(), even when stopped mid-handler with events piled up");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
     public void SkipMissedIntervalsDisabled_CatchesUpMissedTicks(string kind)
     {
         using var timer = CreateTimer(kind);

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -320,6 +320,50 @@ public class TimerBehaviorTests
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]
+    public void SkipMissedIntervals_Enabled_NoBurstAfterDelay(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var timings = new ConcurrentQueue<double>();
+        var firstCall = true;
+
+        timer.Elapsed += (_, args) =>
+        {
+            timings.Enqueue(args.TimeSinceLastInterval.TotalMilliseconds);
+            if (firstCall)
+            {
+                firstCall = false;
+                Thread.Sleep(100); // Block first call so intervals pile up
+            }
+        };
+        timer.SkipMissedIntervals = true;
+        timer.Start();
+        Thread.Sleep(400);
+        timer.Stop();
+
+        var values = timings.ToArray();
+        Assert.That(values, Has.Length.GreaterThan(5));
+        Assert.That(values[0], Is.InRange(10.0, 35.0));    // normal first tick
+        Assert.That(values[1], Is.InRange(70.0, 140.0));   // fires after ~100ms block
+
+        // After at most one short catch-up tick (values[2]), pacing should normalize — no burst
+        var tail = values.Skip(3).ToArray();
+        Assert.That(tail, Is.All.GreaterThanOrEqualTo(10.0), $"{kind}: pacing should resume normally after skip, no sustained burst");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void AutoResetFalse_SkipMissedIntervals_DoesNotPreventFire(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.AutoReset = false;
+        timer.SkipMissedIntervals = true;
+        timer.Elapsed += (_, _) => count++;
+        timer.Start();
+        Thread.Sleep(500);
+        Assert.That(count, Is.EqualTo(1), $"{kind}: AutoReset=false with SkipMissedIntervals=true should still fire exactly once");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
     public void ElapsedArgs_TimeSinceLastInterval_IsValid(string kind)
     {
         using var timer = CreateTimer(kind);

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -385,7 +385,7 @@ public class TimerBehaviorTests
         Assert.That(values[1], Is.InRange(70.0, 140.0));   // fires after ~100ms block
 
         // After at most one short catch-up tick (values[2]), pacing should normalize — no burst
-        var tail = values.Skip(3).ToArray();
+        var tail = values.Skip(4).ToArray();
         Assert.That(tail, Is.All.GreaterThanOrEqualTo(10.0), $"{kind}: pacing should resume normally after skip, no sustained burst");
     }
 


### PR DESCRIPTION
Massive rework now using safehandles for the handles to ensure cleanup and adding functional unitTests (no autorun since tehy can fail because of timing stuff)
Threads now use more local vairables reducing compelxitiy of synchrinizaion betwene fields; locks between start and stop for safety and generally adjusting the 3 timers to now have teh same code structure and the same functional behavior

Fixes #39 