### PR TITLE
Use correct tick scope everywhere

### DIFF
--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -30,7 +30,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
             }
 
             intervalMs = (float)value;
-            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * QuickTickHelper.TicksPerMillisecond));
+            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * QuickTickHelper.StopwatchTicksPerMillisecond));
         }
     }
 
@@ -179,11 +179,11 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
                     break;
                 }
 
-                if (diffTicks >= QuickTickHelper.TicksPerMillisecond * sleepThreshold)
+                if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * sleepThreshold)
                 {
                     QuickTickTiming.MinimalSleep();
                 }
-                else if (diffTicks >= QuickTickHelper.TicksPerMillisecond * yieldThreshold)
+                else if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * yieldThreshold)
                 {
                     Thread.Yield();
                 }
@@ -233,7 +233,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
                 }
             }
 
-            var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
+            var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
             var handler = elapsed;
 

--- a/QuickTickLib/QuickTickHelper.cs
+++ b/QuickTickLib/QuickTickHelper.cs
@@ -5,12 +5,14 @@ namespace QuickTickLib;
 
 internal static class QuickTickHelper
 {
-    internal static readonly long TicksPerMillisecond = Stopwatch.Frequency / 1000;
+    // Converts Stopwatch ticks to TimeSpan/Win32 ticks (100 ns units).
+    private static readonly double StopwatchTicksToTimeSpanTicksFactor = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+    internal static readonly long StopwatchTicksPerMillisecond = Stopwatch.Frequency / 1000;
     internal const uint NtCreateWaitCompletionPacketAccessRights = (uint)Win32Interop.TimerAccessMask.TIMER_MODIFY_STATE | (uint)Win32Interop.TimerAccessMask.TIMER_QUERY_STATE;
     internal const uint CreateWaitableTimerExWAccessRights = (uint)Win32Interop.TimerAccessMask.TIMER_MODIFY_STATE | (uint)Win32Interop.TimerAccessMask.SYNCHRONIZE;
     private const int MinRequiredWindowsBuildNumber = 17134; // This is the build number of Windows 10 Version 1803
     private static readonly Version? WindowsVersion = GetWindowsVersion();
-
+    
     internal static bool PlatformSupportsQuickTick()
     {
         if (WindowsVersion is null)
@@ -42,5 +44,10 @@ internal static class QuickTickHelper
         // Environment.OSVersion.Version would return MajorVersion 6 in .NET Framework without manifest file.
         return Win32Interop.GetRealWindowsVersion();
 #endif
+    }
+    
+    internal static long StopwatchTicksToTimeSpanTicks(long stopwatchTicks)
+    {
+        return (long)(stopwatchTicks * StopwatchTicksToTimeSpanTicksFactor);
     }
 }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -161,7 +161,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
                 }
             }
 
-            var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
+            var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
             var handler = elapsed;
 

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -42,7 +42,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             }
 
             intervalMs = (float)value;
-            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * QuickTickHelper.TicksPerMillisecond));
+            Interlocked.Exchange(ref intervalTicks, (long)(intervalMs * QuickTickHelper.StopwatchTicksPerMillisecond));
         }
     }
 
@@ -191,7 +191,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
                 SetTimer(stopWatch, nextFireTicks, runKey);
             }
 
-            var timeSinceLastFire = TimeSpan.FromTicks(currentTicks - lastFireTicksLocal);
+            var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
             var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
             var handler = elapsed;
 
@@ -209,8 +209,9 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     
     private void SetTimer(Stopwatch stopWatch, long nextFireTicks, IntPtr runKey)
     {
-        long dueTime = nextFireTicks - stopWatch.ElapsedTicks;
-        dueTime = dueTime < 0 ? 0 : -dueTime; // Negative = relative time for SetWaitableTimer
+        long dueTimeStopwatchTicks = nextFireTicks - stopWatch.ElapsedTicks;
+        long dueTime = dueTimeStopwatchTicks < 0 ? 0 : QuickTickHelper.StopwatchTicksToTimeSpanTicks(dueTimeStopwatchTicks);
+        dueTime = -dueTime; // Negative = relative time for SetWaitableTimer, which expects 100ns units
 
         if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false)) // Setting the period to 0 makes the timer fire exactly once
         {

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -5,7 +5,8 @@ namespace QuickTickLib;
 public static class QuickTickTiming
 {
     // Testing showed that waiting 0.5ms results in around 1ms average waiting while going to 0.4ms results in an average of 0.5ms wait time
-    private static readonly long FourHundredMicroSecondInTicks = (long)(QuickTickHelper.TicksPerMillisecond * 0.4);
+    // QuickTickSleep expects 100ns (TimeSpan) ticks, same as its other caller Sleep(), so this must be derived from TimeSpan.TicksPerMillisecond
+    private const long FourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
     private static readonly IntPtr SuccessCompletionKey = new(1);
 
     // Settable in tests (InternalsVisibleTo("QuickTickTests")) to exercise the Thread.Sleep/Task.Delay fallback path
@@ -66,7 +67,11 @@ public static class QuickTickTiming
             Thread.Sleep(1);
         }
     }
-
+    
+    /// <summary>
+    /// The tickToSleep must be specified in <see cref="TimeSpan"/> ticks (100-nanosecond
+    /// intervals), not <see cref="System.Diagnostics.Stopwatch"/> ticks, because WinAPI calls want it that way.
+    /// </summary>
     internal static void QuickTickSleep(long tickToSleep)
     {
         using var handles = new QuickTickHandleResources();

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -184,7 +184,7 @@ public class TimerBehaviorTests
         
         proc.Refresh();
         var threadsAfterDispose = proc.Threads.Count;
-        Assert.That(threadsAfterDispose - threadsBeforeTimerCreation, Is.Zero, $"{kind}: Creating and disposing a timer left a ghost thread");
+        Assert.That(threadsAfterDispose - threadsBeforeTimerCreation, Is.LessThanOrEqualTo(0), $"{kind}: Creating and disposing a timer left a ghost thread");
     }
     
     [TestCaseSource(nameof(AllTimerKinds))]

--- a/QuickTickTimingReportGenerator/Program.cs
+++ b/QuickTickTimingReportGenerator/Program.cs
@@ -214,7 +214,7 @@ class Program
         Thread.CurrentThread.Priority = priority;
         Thread.Sleep(100);
 
-        var sleepTicks = (int)(QuickTickHelper.TicksPerMillisecond * durationMs);
+        var sleepTicks = (int)(TimeSpan.TicksPerMillisecond * durationMs);
 
         var samples = new List<double>();
         int progressInterval = Math.Max(1, iterations / 10);


### PR DESCRIPTION
theres a big difference between timeSpan.Ticks and Stopwatch.Ticks and now its converted cleanly everywhere; Tests allready covered the case and now they pass;

Fixes #57 