### PR TITLE
Lifecycle fixes

### DIFF
--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -305,7 +305,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     {
         if (Volatile.Read(ref _disposedState) == 1)
         {
-            throw new ObjectDisposedException(GetType().Name);
+            throw new ObjectDisposedException(nameof(HighResQuickTickTimer));
         }
     }
 }

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -14,11 +14,12 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     private volatile float _yieldThreshold = 0.75f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensively testing with the TimingReportGenerator
     private long _intervalTicks;
     private ThreadPriority _threadPriority = ThreadPriority.Highest;
-    private CancellationTokenSource? _cancellationTokenSource;
-    private Thread? _workerThread;
+    private HighResQuickTickTimerRun? _currentRun;
+    private Thread? _retiringThread;
+    private int _disposedState;
     private readonly object _stateLock = new();
 
-    internal Thread? WorkerThreadForTests => _workerThread;
+    internal Thread? WorkerThreadForTests => _currentRun?.Thread;
 
     public double Interval
     {
@@ -53,9 +54,9 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
         set
         {
             _threadPriority = value;
-            if (_workerThread is { IsAlive: true })
+            if (_currentRun?.Thread is { IsAlive: true } workerThread)
             {
-                _workerThread.Priority = value;
+                workerThread.Priority = value;
             }
         }
     }
@@ -119,137 +120,192 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     {
         lock (_stateLock)
         {
+            ThrowIfDisposed();
+
             if (_running)
             {
                 return;
             }
 
-            _running = true;
-            var cts = new CancellationTokenSource();
-
-            _workerThread = new Thread(() => RunTimer(cts))
+            // Construct the run before setting any state so a failing handle creation leaves the timer stopped
+            var run = new HighResQuickTickTimerRun();
+            run.Thread = new Thread(() => RunTimer(run))
             {
                 IsBackground = true,
                 Priority = Priority,
                 Name = "QuickTick Timer"
             };
 
-            _cancellationTokenSource = cts;
-            _workerThread.Start();
+            _currentRun = run;
+            _running = true;
+            run.Thread.Start();
         }
     }
 
     public void Stop()
     {
+        Thread? threadToJoin;
+
         lock (_stateLock)
         {
-            if (!_running)
+            if (_running)
             {
-                return;
+                _running = false;
+
+                var run = _currentRun!; // While _running is true a current run always exists
+                run.CancellationTokenSource.Cancel();
+                _currentRun = null;
+
+                if (Thread.CurrentThread == run.Thread)
+                {
+                    // Called from the Elapsed handler: the worker exits and disposes its run on its own after the handler returns
+                    return;
+                }
+
+                _retiringThread = run.Thread;
             }
 
-            _running = false;
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource = null;
-            
-            if (Thread.CurrentThread != _workerThread)
+            threadToJoin = _retiringThread;
+        }
+
+        if (threadToJoin != null && threadToJoin != Thread.CurrentThread)
+        {
+            // Join outside the lock: an Elapsed handler calling Stop()/Dispose() concurrently blocks on the
+            // state lock, so joining while holding it would deadlock against the very thread being joined
+            threadToJoin.Join();
+
+            lock (_stateLock)
             {
-                _workerThread?.Join();
+                if (_retiringThread == threadToJoin)
+                {
+                    _retiringThread = null;
+                }
             }
-            _workerThread = null;
         }
     }
 
-    private void RunTimer(CancellationTokenSource localCancellationTokenSource)
+    private void RunTimer(HighResQuickTickTimerRun run)
     {
-        var stopWatch = Stopwatch.StartNew();
-        var nextTriggerTicks = Interlocked.Read(ref _intervalTicks);
-        var skippedIntervals = 0L;
-        var lastFireTicks = 0L;
-
-        while (!localCancellationTokenSource.IsCancellationRequested)
+        try
         {
-            while (true)
+            var stopWatch = Stopwatch.StartNew();
+            var nextTriggerTicks = Interlocked.Read(ref _intervalTicks);
+            var skippedIntervals = 0L;
+            var lastFireTicks = 0L;
+
+            while (!run.CancellationTokenSource.IsCancellationRequested)
             {
-                var diffTicks = nextTriggerTicks - stopWatch.ElapsedTicks;
-                if (diffTicks <= 0)
+                while (true)
                 {
-                    break;
-                }
-
-                if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * _sleepThreshold)
-                {
-                    QuickTickTiming.MinimalSleep();
-                }
-                else if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * _yieldThreshold)
-                {
-                    Thread.Yield();
-                }
-                else
-                {
-                    Thread.SpinWait(10);
-                }
-
-                if (localCancellationTokenSource.IsCancellationRequested)
-                {
-                    break;
-                }
-            }
-
-            if (localCancellationTokenSource.IsCancellationRequested)
-            {
-                break;
-            }
-
-            var currentTicks = stopWatch.ElapsedTicks;
-            var lastFireTicksLocal = lastFireTicks;
-            lastFireTicks = currentTicks;
-
-            if (_autoReset)
-            {
-                var interval = Interlocked.Read(ref _intervalTicks);
-                nextTriggerTicks += interval;
-
-                if (_skipMissedIntervals)
-                {
-                    while (nextTriggerTicks < currentTicks)
+                    var diffTicks = nextTriggerTicks - stopWatch.ElapsedTicks;
+                    if (diffTicks <= 0)
                     {
-                        nextTriggerTicks += interval;
-                        if (skippedIntervals < long.MaxValue)
-                        {
-                            skippedIntervals++;
-                        }
+                        break;
+                    }
+
+                    if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * _sleepThreshold)
+                    {
+                        QuickTickTiming.MinimalSleep(run.Handles);
+                    }
+                    else if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * _yieldThreshold)
+                    {
+                        Thread.Yield();
+                    }
+                    else
+                    {
+                        Thread.SpinWait(10);
+                    }
+
+                    if (run.CancellationTokenSource.IsCancellationRequested)
+                    {
+                        break;
                     }
                 }
 
-                if (stopWatch.Elapsed.TotalHours >= 1)
+                if (run.CancellationTokenSource.IsCancellationRequested)
                 {
-                    var remaining = nextTriggerTicks - currentTicks;
-                    stopWatch.Restart();
-                    nextTriggerTicks = remaining;
-                    lastFireTicks = 0L;
+                    break;
+                }
+
+                var currentTicks = stopWatch.ElapsedTicks;
+                var lastFireTicksLocal = lastFireTicks;
+                lastFireTicks = currentTicks;
+
+                if (_autoReset)
+                {
+                    var interval = Interlocked.Read(ref _intervalTicks);
+                    nextTriggerTicks += interval;
+
+                    if (_skipMissedIntervals)
+                    {
+                        while (nextTriggerTicks < currentTicks)
+                        {
+                            nextTriggerTicks += interval;
+                            if (skippedIntervals < long.MaxValue)
+                            {
+                                skippedIntervals++;
+                            }
+                        }
+                    }
+
+                    if (stopWatch.Elapsed.TotalHours >= 1)
+                    {
+                        var remaining = nextTriggerTicks - currentTicks;
+                        stopWatch.Restart();
+                        nextTriggerTicks = remaining;
+                        lastFireTicks = 0L;
+                    }
+                }
+
+                var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
+                var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
+                var handler = Elapsed;
+
+                if (!_autoReset)
+                {
+                    _running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
+                    run.CancellationTokenSource.Cancel();
+                    handler?.Invoke(this, elapsedEventArgs);
+                    break;
+                }
+
+                handler?.Invoke(this, elapsedEventArgs);
+            }
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                // Unlink if the run ended on its own (AutoReset = false or a throwing handler); Stop() unlinks otherwise
+                if (_currentRun == run)
+                {
+                    _currentRun = null;
+                    _running = false;
                 }
             }
 
-            var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
-            var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
-            var handler = Elapsed;
-
-            if (!_autoReset)
-            {
-                _running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
-                localCancellationTokenSource.Cancel();
-                handler?.Invoke(this, elapsedEventArgs);
-                break;
-            }
-
-            handler?.Invoke(this, elapsedEventArgs);
+            // Outside the lock on purpose: once the run is unlinked Stop() can no longer reach these objects,
+            // so disposing them cannot race the Cancel() call that only targets the current run
+            run.Dispose();
         }
     }
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposedState, 1) == 1)
+        {
+            return;
+        }
+
         Stop();
         Elapsed = null;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposedState) == 1)
+        {
+            throw new ObjectDisposedException(GetType().Name);
+        }
     }
 }

--- a/QuickTickLib/HighResQuickTickTimerRun.cs
+++ b/QuickTickLib/HighResQuickTickTimerRun.cs
@@ -1,0 +1,23 @@
+namespace QuickTickLib;
+
+// Bundles everything a single high-res timer run owns: the cached sleep timer handles (where the platform
+// has them), the cancellation source and the worker thread. Created by Start(); disposed by the worker
+// thread itself on exit, after it unlinked the run under the state lock so Stop() can no longer reach
+// these objects. Unlike QuickTickTimerRun there is no stop event: the spin/sleep/yield loop never blocks
+// for longer than one MinimalSleep, so polling the cancellation token is enough to stop promptly.
+internal sealed class HighResQuickTickTimerRun : IDisposable
+{
+    // Null where the platform has no Win32 waitable timers (this timer runs everywhere);
+    // MinimalSleep falls back to Thread.Sleep on its own then
+    public readonly QuickTickHandleResources? Handles = QuickTickTiming.IsQuickTickSupported ? new QuickTickHandleResources() : null;
+    public readonly CancellationTokenSource CancellationTokenSource = new();
+    public Thread Thread = null!; // Set by Start() right after construction; the thread's loop closes over this run
+
+    public void Dispose()
+    {
+        Handles?.Dispose();
+        // The CancellationTokenSource is deliberately not disposed: without CancelAfter() and without accessing
+        // its WaitHandle property it creates no unmanaged resources, so the GC reclaims it on its own. Disposing
+        // it would only risk an ObjectDisposedException on a racing Cancel() for no gain.
+    }
+}

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -110,7 +110,8 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
         }
     }
 
-    private void OnElapsedInternal(object? sender, ElapsedEventArgs e)
+    // Internal for tests: called directly to simulate the timer callback racing Stop() without System.Timers.Timer swallowing exceptions
+    internal void OnElapsedInternal(object? sender, ElapsedEventArgs e)
     {
         // Use tryAdd because the timer could still fire after Stop() which would cause exception because Stop() also call CompleteAdding() on the queue
         _eventQueue?.TryAdd(true);

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -16,6 +16,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     private ThreadPriority _threadPriority = ThreadPriority.Normal;
     private CancellationTokenSource? _cancellationTokenSource;
     private Thread? _workerThread;
+    private Thread? _retiringThread;
     private readonly object _stateLock = new();
 
     internal Thread? WorkerThreadForTests => _workerThread;
@@ -64,6 +65,8 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     {
         lock (_stateLock)
         {
+            ThrowIfDisposed();
+
             if (_running)
             {
                 return;
@@ -89,32 +92,64 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
 
     public void Stop()
     {
+        Thread? threadToJoin;
+
         lock (_stateLock)
         {
-            if (!_running)
+            if (_running)
             {
-                return;
+                _running = false;
+                // Cancelled but deliberately not disposed: a plain CancellationTokenSource (no CancelAfter(), no
+                // WaitHandle access) creates no unmanaged resources, so the GC reclaims it on its own
+                _cancellationTokenSource?.Cancel();
+                _cancellationTokenSource = null;
+                _timer.Stop();
+                _eventQueue?.CompleteAdding();
+
+                if (Thread.CurrentThread == _workerThread)
+                {
+                    // Called from the Elapsed handler: the worker exits on its own after the handler returns
+                    _workerThread = null;
+                    return;
+                }
+
+                _retiringThread = _workerThread;
+                _workerThread = null;
             }
 
-            _running = false;
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource = null;
-            _timer.Stop();
-            _eventQueue?.CompleteAdding();
+            threadToJoin = _retiringThread;
+        }
 
-            if (Thread.CurrentThread != _workerThread)
+        if (threadToJoin != null && threadToJoin != Thread.CurrentThread)
+        {
+            // Join outside the lock: an Elapsed handler calling Stop()/Dispose() concurrently blocks on the
+            // state lock, so joining while holding it would deadlock against the very thread being joined
+            threadToJoin.Join();
+
+            lock (_stateLock)
             {
-                _workerThread?.Join();
+                if (_retiringThread == threadToJoin)
+                {
+                    _retiringThread = null;
+                }
             }
-            _workerThread = null;
         }
     }
 
     // Internal for tests: called directly to simulate the timer callback racing Stop() without System.Timers.Timer swallowing exceptions
     internal void OnElapsedInternal(object? sender, ElapsedEventArgs e)
     {
-        // Use tryAdd because the timer could still fire after Stop() which would cause exception because Stop() also call CompleteAdding() on the queue
-        _eventQueue?.TryAdd(true);
+        try
+        {
+            // The timer can still fire after Stop(): once Stop() called CompleteAdding() this TryAdd throws
+            // InvalidOperationException (it does NOT return false). A pre-check on IsAddingCompleted would still
+            // race with Stop(), so the exception is caught instead.
+            _eventQueue?.TryAdd(true);
+        }
+        catch (InvalidOperationException)
+        {
+            // Late callback after Stop(); nothing to do
+        }
     }
 
     private void Run(CancellationTokenSource localCancellationTokenSource, BlockingCollection<bool> localEventQueue)
@@ -191,6 +226,14 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
         {
             _timer.Dispose();
             Elapsed = null;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposedState) == 1)
+        {
+            throw new ObjectDisposedException(GetType().Name);
         }
     }
 }

--- a/QuickTickLib/QuickTickTimerFallback.cs
+++ b/QuickTickLib/QuickTickTimerFallback.cs
@@ -233,7 +233,7 @@ internal sealed class QuickTickTimerFallback : IQuickTickTimer
     {
         if (Volatile.Read(ref _disposedState) == 1)
         {
-            throw new ObjectDisposedException(GetType().Name);
+            throw new ObjectDisposedException(nameof(QuickTickTimerFallback));
         }
     }
 }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -7,8 +7,6 @@ namespace QuickTickLib;
 
 internal sealed class QuickTickTimerImplementation : IQuickTickTimer
 {
-    private readonly QuickTickHandleResources _handles;
-
     private volatile bool _autoReset;
     private volatile bool _skipMissedIntervals;
     private volatile bool _running;
@@ -18,12 +16,11 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     private int _disposedState;
     private readonly object _stateLock = new();
 
-    private CancellationTokenSource? _cancellationTokenSource;
-    private ManualResetEvent? _stopEvent;
-    private Thread? _workerThread;
+    private QuickTickTimerRun? _currentRun;
+    private Thread? _retiringThread;
     private ThreadPriority _threadPriority = ThreadPriority.Normal;
 
-    internal Thread? WorkerThreadForTests => _workerThread;
+    internal Thread? WorkerThreadForTests => _currentRun?.Thread;
 
     public event QuickTickElapsedEventHandler? Elapsed;
 
@@ -60,9 +57,9 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
         set
         {
             _threadPriority = value;
-            if (_workerThread is { IsAlive: true })
+            if (_currentRun?.Thread is { IsAlive: true } workerThread)
             {
-                _workerThread.Priority = value;
+                workerThread.Priority = value;
             }
         }
     }
@@ -71,147 +68,177 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     {
         AutoReset = true;
         Interval = interval;
-        _handles = new QuickTickHandleResources();
     }
 
     public void Start()
     {
         lock (_stateLock)
         {
+            ThrowIfDisposed();
+
             if (_running)
             {
                 return;
             }
 
-            _running = true;
-            var cts = new CancellationTokenSource();
-
-            // A leftover event exists when the previous run ended itself (AutoReset = false); its exited thread never waits on it again
-            _stopEvent?.Dispose();
-            var localStopEvent = new ManualResetEvent(false);
-
-            _workerThread = new Thread(() => WorkerThreadLoop(cts, localStopEvent))
+            // Construct the run before setting any state so a failing handle creation leaves the timer stopped
+            var run = new QuickTickTimerRun();
+            run.Thread = new Thread(() => WorkerThreadLoop(run))
             {
                 IsBackground = true,
                 Priority = Priority,
                 Name = "QuickTick Timer"
             };
 
-            _cancellationTokenSource = cts;
-            _stopEvent = localStopEvent;
-            _workerThread.Start();
+            _currentRun = run;
+            _running = true;
+            run.Thread.Start();
         }
     }
 
     public void Stop()
     {
+        Thread? threadToJoin;
+
         lock (_stateLock)
         {
-            if (!_running)
+            if (_running)
             {
-                return;
+                _running = false;
+
+                var run = _currentRun!; // While _running is true a current run always exists
+                run.CancellationTokenSource.Cancel();
+                run.StopEvent.Set(); // Wake the worker thread out of its wait
+                _currentRun = null;
+
+                if (Thread.CurrentThread == run.Thread)
+                {
+                    // Called from the Elapsed handler: the worker exits and disposes its run on its own after the handler returns
+                    return;
+                }
+
+                _retiringThread = run.Thread;
             }
 
-            _running = false;
-            _cancellationTokenSource?.Cancel();
-            _cancellationTokenSource = null;
+            threadToJoin = _retiringThread;
+        }
 
-            Win32Interop.CancelWaitableTimer(_handles.TimerHandle);
+        if (threadToJoin != null && threadToJoin != Thread.CurrentThread)
+        {
+            // Join outside the lock: an Elapsed handler calling Stop()/Dispose() concurrently blocks on the
+            // state lock, so joining while holding it would deadlock against the very thread being joined
+            threadToJoin.Join();
 
-            if (Thread.CurrentThread != _workerThread)
+            lock (_stateLock)
             {
-                // Wake the worker thread out of its wait
-                // If called from the same thread we know we are called from the event handler code therefore we are not waiting on the timer and don't need to signal
-                _stopEvent?.Set();
-
-                _workerThread?.Join();
+                if (_retiringThread == threadToJoin)
+                {
+                    _retiringThread = null;
+                }
             }
-            _workerThread = null;
-
-            // Safe even in the self-stop case: after the handler returns the worker thread only checks the cancellation token and exits, it never waits again
-            _stopEvent?.Dispose();
-            _stopEvent = null;
         }
     }
 
-    private void WorkerThreadLoop(CancellationTokenSource localCancellationTokenSource, ManualResetEvent localStopEvent)
+    private void WorkerThreadLoop(QuickTickTimerRun run)
     {
-        // The timer is a synchronization (auto-reset) timer: a satisfied wait resets it and SetWaitableTimer resets any pending signal on re-arm,
-        // so no stale signal can leak across Stop/Start cycles
-        var waitHandles = new[] { _handles.TimerWaitHandle, localStopEvent };
-
-        var stopWatch = Stopwatch.StartNew();
-        var nextFireTicks = Interlocked.Read(ref _intervalTicks);
-        var lastFireTicks = 0L;
-        var skippedIntervals = 0L;
-
-        SetTimer(stopWatch, nextFireTicks);
-
-        while (!localCancellationTokenSource.IsCancellationRequested)
+        try
         {
-            var signaledIndex = WaitHandle.WaitAny(waitHandles);
+            // The timer is a synchronization (auto-reset) timer owned exclusively by this run: a satisfied wait
+            // resets it, so every SetTimer/WaitAny pair consumes exactly one signal and no other run can interfere
+            var waitHandles = new[] { run.Handles.TimerWaitHandle, run.StopEvent };
 
-            if (localCancellationTokenSource.IsCancellationRequested || signaledIndex != 0)
+            var stopWatch = Stopwatch.StartNew();
+            var nextFireTicks = Interlocked.Read(ref _intervalTicks);
+            var lastFireTicks = 0L;
+            var skippedIntervals = 0L;
+
+            SetTimer(run, stopWatch, nextFireTicks);
+
+            while (!run.CancellationTokenSource.IsCancellationRequested)
             {
-                break;
-            }
+                var signaledIndex = WaitHandle.WaitAny(waitHandles);
 
-            var currentTicks = stopWatch.ElapsedTicks;
-            var lastFireTicksLocal = lastFireTicks;
-            lastFireTicks = currentTicks;
-
-            if (_autoReset)
-            {
-                var interval = Interlocked.Read(ref _intervalTicks);
-                nextFireTicks += interval;
-
-                if (_skipMissedIntervals)
+                if (run.CancellationTokenSource.IsCancellationRequested || signaledIndex != 0)
                 {
-                    while (nextFireTicks < currentTicks)
+                    break;
+                }
+
+                var currentTicks = stopWatch.ElapsedTicks;
+                var lastFireTicksLocal = lastFireTicks;
+                lastFireTicks = currentTicks;
+
+                if (_autoReset)
+                {
+                    var interval = Interlocked.Read(ref _intervalTicks);
+                    nextFireTicks += interval;
+
+                    if (_skipMissedIntervals)
                     {
-                        nextFireTicks += interval;
-                        if (skippedIntervals < long.MaxValue)
+                        while (nextFireTicks < currentTicks)
                         {
-                            skippedIntervals++;
+                            nextFireTicks += interval;
+                            if (skippedIntervals < long.MaxValue)
+                            {
+                                skippedIntervals++;
+                            }
                         }
                     }
+
+                    if (stopWatch.Elapsed.TotalHours >= 1)
+                    {
+                        var remaining = nextFireTicks - currentTicks;
+                        stopWatch.Restart();
+                        nextFireTicks = remaining;
+                        lastFireTicks = 0;
+                    }
+
+                    SetTimer(run, stopWatch, nextFireTicks);
                 }
 
-                if (stopWatch.Elapsed.TotalHours >= 1)
+                var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
+                var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
+                var handler = Elapsed;
+
+                if (!_autoReset)
                 {
-                    var remaining = nextFireTicks - currentTicks;
-                    stopWatch.Restart();
-                    nextFireTicks = remaining;
-                    lastFireTicks = 0;
+                    _running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
+                    run.CancellationTokenSource.Cancel();
+                    handler?.Invoke(this, elapsedEventArgs);
+                    break;
                 }
 
-                SetTimer(stopWatch, nextFireTicks);
-            }
-
-            var timeSinceLastFire = TimeSpan.FromTicks(QuickTickHelper.StopwatchTicksToTimeSpanTicks(currentTicks - lastFireTicksLocal));
-            var elapsedEventArgs = new QuickTickElapsedEventArgs(timeSinceLastFire, skippedIntervals);
-            var handler = Elapsed;
-
-            if (!_autoReset)
-            {
-                _running = false; // Same logic as System.Timers.Timer: set running=false before invoking the handler when AutoReset is disabled
-                localCancellationTokenSource.Cancel();
                 handler?.Invoke(this, elapsedEventArgs);
-                break;
+            }
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                // Unlink if the run ended on its own (AutoReset = false or a throwing handler); Stop() unlinks otherwise
+                if (_currentRun == run)
+                {
+                    _currentRun = null;
+                    _running = false;
+                }
             }
 
-            handler?.Invoke(this, elapsedEventArgs);
+            // Outside the lock on purpose: once the run is unlinked Stop() can no longer reach these objects,
+            // so disposing them cannot race the Cancel()/Set() calls that only target the current run
+            run.Dispose();
         }
     }
 
-    private void SetTimer(Stopwatch stopWatch, long nextFireTicks)
+    private static void SetTimer(QuickTickTimerRun run, Stopwatch stopWatch, long nextFireTicks)
     {
         long dueTimeStopwatchTicks = nextFireTicks - stopWatch.ElapsedTicks;
         long dueTime = dueTimeStopwatchTicks < 0 ? 0 : QuickTickHelper.StopwatchTicksToTimeSpanTicks(dueTimeStopwatchTicks);
         dueTime = -dueTime; // Negative = relative time for SetWaitableTimer, which expects 100ns units
 
-        if (!Win32Interop.SetWaitableTimer(_handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false)) // Setting the period to 0 makes the timer fire exactly once
+        if (!Win32Interop.SetWaitableTimer(run.Handles.TimerHandle, ref dueTime, 0, IntPtr.Zero, IntPtr.Zero, false)) // Setting the period to 0 makes the timer fire exactly once
         {
+            // With the Start()-after-Dispose guard in place this cannot realistically fail (valid handle, valid arguments).
+            // If it ever does, the exception propagates on the worker thread where user code cannot catch it — deliberate,
+            // matching the documented behavior of exceptions thrown from Elapsed handlers.
             throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
         }
     }
@@ -223,14 +250,16 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
             return;
         }
 
-        try
+        // All kernel resources are owned by the runs and disposed by their worker threads; there is nothing else to release
+        Stop();
+        Elapsed = null;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposedState) == 1)
         {
-            Stop();
-        }
-        finally
-        {
-            _handles.Dispose();
-            Elapsed = null;
+            throw new ObjectDisposedException(GetType().Name);
         }
     }
 }

--- a/QuickTickLib/QuickTickTimerImplementation.cs
+++ b/QuickTickLib/QuickTickTimerImplementation.cs
@@ -259,7 +259,7 @@ internal sealed class QuickTickTimerImplementation : IQuickTickTimer
     {
         if (Volatile.Read(ref _disposedState) == 1)
         {
-            throw new ObjectDisposedException(GetType().Name);
+            throw new ObjectDisposedException(nameof(QuickTickTimerImplementation));
         }
     }
 }

--- a/QuickTickLib/QuickTickTimerRun.cs
+++ b/QuickTickLib/QuickTickTimerRun.cs
@@ -1,0 +1,21 @@
+namespace QuickTickLib;
+
+// Bundles everything a single timer run owns: the kernel timer handles, the stop signal, the cancellation
+// source and the worker thread. Created by Start(); disposed by the worker thread itself on exit, after it
+// unlinked the run under the state lock so Stop() can no longer reach these objects.
+internal sealed class QuickTickTimerRun : IDisposable
+{
+    public readonly QuickTickHandleResources Handles = new();
+    public readonly ManualResetEvent StopEvent = new(false);
+    public readonly CancellationTokenSource CancellationTokenSource = new();
+    public Thread Thread = null!; // Set by Start() right after construction; the thread's loop closes over this run
+
+    public void Dispose()
+    {
+        StopEvent.Dispose();
+        Handles.Dispose();
+        // The CancellationTokenSource is deliberately not disposed: without CancelAfter() and without accessing
+        // its WaitHandle property it creates no unmanaged resources, so the GC reclaims it on its own. Disposing
+        // it would only risk an ObjectDisposedException on a racing Cancel() for no gain.
+    }
+}

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -68,18 +68,24 @@ public static class QuickTickTiming
         QuickTickSleep(sleepTimeTicks);
     }
 
-    internal static void MinimalSleep()
+    // cachedHandles can be null when the platform has no waitable timers (or a test flipped IsQuickTickSupported
+    // after the caller created its run); the caller keeps ownership and disposes them
+    internal static void MinimalSleep(QuickTickHandleResources? cachedHandles)
     {
-        if (IsQuickTickSupported)
-        {       
-            QuickTickSleep(FourHundredMicroSecondInTicks);
-        }
-        else
+        if (!IsQuickTickSupported)
         {
             Thread.Sleep(1);
         }
+        else if (cachedHandles != null)
+        {
+            QuickTickSleep(cachedHandles, FourHundredMicroSecondInTicks);
+        }
+        else
+        {
+            QuickTickSleep(FourHundredMicroSecondInTicks);
+        }
     }
-    
+
     /// <summary>
     /// The tickToSleep must be specified in <see cref="TimeSpan"/> ticks (100-nanosecond
     /// intervals), not <see cref="System.Diagnostics.Stopwatch"/> ticks, because WinAPI calls want it that way.
@@ -87,7 +93,11 @@ public static class QuickTickTiming
     internal static void QuickTickSleep(long tickToSleep)
     {
         using var handles = new QuickTickHandleResources();
+        QuickTickSleep(handles, tickToSleep);
+    }
 
+    private static void QuickTickSleep(QuickTickHandleResources handles, long tickToSleep)
+    {
         var sleepTimeTicks = -tickToSleep; // Negative means relative time
 
         if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref sleepTimeTicks, 0, IntPtr.Zero, IntPtr.Zero, false))

--- a/QuickTickTests/TimerBehaviorTests.cs
+++ b/QuickTickTests/TimerBehaviorTests.cs
@@ -40,14 +40,6 @@ public class TimerBehaviorTests
         _                => throw new ArgumentException($"Unknown timer kind: {kind}", nameof(kind))
     };
 
-    private static Thread? GetWorkerThread(IQuickTickTimer timer) => timer switch
-    {
-        QuickTickTimerImplementation impl => impl.WorkerThreadForTests,
-        QuickTickTimerFallback fallback   => fallback.WorkerThreadForTests,
-        HighResQuickTickTimer highRes     => highRes.WorkerThreadForTests,
-        _                                 => throw new ArgumentException($"Unknown timer type: {timer.GetType()}", nameof(timer))
-    };
-    
     [TestCaseSource(nameof(AllTimerKinds))]
     public void Basic_Timer_Creation(string kind)
     {
@@ -98,97 +90,6 @@ public class TimerBehaviorTests
         Assert.That(count, Is.EqualTo(1));
     }
 
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void MultipleStops_DoNotThrow(string kind)
-    {
-        using var timer = CreateTimer(kind);
-        timer.Start();
-        timer.Stop();
-        timer.Stop();
-        timer.Stop();
-    }
-
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void MultipleStarts_AreIgnored(string kind)
-    {
-        using var timer = CreateTimer(kind);
-        var count = 0;
-        timer.Elapsed += (_, _) => count++;
-
-        timer.Start();
-        var workerAfterFirstStart = GetWorkerThread(timer);
-        Assert.That(workerAfterFirstStart, Is.Not.Null, $"{kind}: Start() should have spawned a worker thread");
-
-        timer.Start();
-        timer.Start();
-        timer.Start();
-        timer.Start();
-
-        var workerAfterMultipleStarts = GetWorkerThread(timer);
-        Assert.That(ReferenceEquals(workerAfterFirstStart, workerAfterMultipleStarts), Is.True, $"{kind}: subsequent Start() calls replaced the worker thread instead of being ignored");
-        Assert.That(workerAfterFirstStart!.IsAlive, Is.True, $"{kind}: subsequent Start() calls killed the running worker thread");
-
-        Thread.Sleep(500); // Run for ~500ms
-        timer.Stop();
-
-        Assert.That(count, Is.InRange(14, 37)); // One timer should run only, still expect ~32 fires
-    }
-
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void StartAfterStop_FiresAgain(string kind)
-    {
-        using var timer = CreateTimer(kind);
-        var count = 0;
-        timer.Elapsed += (_, _) => count++;
-
-        timer.Start();
-        Thread.Sleep(100);
-        timer.Stop();
-        var countFirstRun = count;
-        Assert.That(countFirstRun, Is.GreaterThan(0), $"{kind}: expected fires during first run");
-
-        timer.Start();
-        Thread.Sleep(100);
-        timer.Stop();
-        Assert.That(count, Is.GreaterThan(countFirstRun), $"{kind}: expected fires during second run");
-    }
-    
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void StopFromHandler_DoesNotDeadlock(string kind)
-    {
-        using var timer = CreateTimer(kind);
-        var done = new ManualResetEventSlim(false);
-        timer.Elapsed += (_, _) =>
-        {
-            // ReSharper disable once AccessToDisposedClosure
-            timer.Stop();
-            done.Set();
-        };
-        timer.Start();
-        Assert.That(done.Wait(TimeSpan.FromMilliseconds(200)), Is.True, $"{kind}: Stop() from handler deadlocked or timed out");
-    }
-    
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void Dispose_StopsTimer(string kind)
-    {
-        var timer = CreateTimer(kind);
-        var count = 0;
-        var firstFired = new ManualResetEventSlim(false);
-        timer.Elapsed += (_, _) => { count++; firstFired.Set(); };
-        timer.Start();
-        Assert.That(firstFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True);
-
-        var workerThread = GetWorkerThread(timer);
-        Assert.That(workerThread, Is.Not.Null, $"{kind}: Start() should have spawned a worker thread");
-
-        timer.Dispose();
-        var countAtDispose = count;
-        Thread.Sleep(150);
-        Assert.That(count, Is.EqualTo(countAtDispose));
-
-        Assert.That(workerThread!.IsAlive, Is.False, $"{kind}: Dispose() left the worker thread running");
-    }
-    
     [TestCaseSource(nameof(AllTimerKinds))]
     public void SkipMissedIntervals_ReportsSkippedCount(string kind)
     {
@@ -324,54 +225,6 @@ public class TimerBehaviorTests
         Assert.That(forthTime, Is.InRange(0.0, 5.0));
     }
     
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void AutoResetFalse_StartFromHandler_RestartsTimer(string kind)
-    {
-        using var timer = CreateTimer(kind);
-        var fireCount = 0;
-        var secondFired = new ManualResetEventSlim(false);
-
-        timer.AutoReset = false;
-        timer.Elapsed += (_, _) =>
-        {
-            fireCount++;
-            if (fireCount == 1)
-            {
-                // ReSharper disable once AccessToDisposedClosure
-                timer.Start();
-            }
-            else
-            {
-                secondFired.Set();
-            }
-        };
-
-        timer.Start();
-        Assert.That(secondFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True, $"{kind}: Start() from AutoReset=false handler should restart the timer");
-        timer.Stop();
-    }
-
-    [TestCaseSource(nameof(AllTimerKinds))]
-    public void Stop_BlocksUntilCurrentHandlerCompletes(string kind)
-    {
-        using var timer = CreateTimer(kind);
-        var handlerStarted  = new ManualResetEventSlim(false);
-        var handlerFinished = new ManualResetEventSlim(false);
-
-        timer.Elapsed += (_, _) =>
-        {
-            handlerStarted.Set();
-            Thread.Sleep(150);
-            handlerFinished.Set();
-        };
-
-        timer.Start();
-        Assert.That(handlerStarted.Wait(TimeSpan.FromMilliseconds(500)), Is.True, "handler should start within 500 ms");
-
-        timer.Stop();
-        Assert.That(handlerFinished.IsSet, Is.True, $"{kind}: Stop() must block until the handler completes (thread join)");
-    }
-
     [TestCaseSource(nameof(AllTimerKinds))]
     public void SkipMissedIntervals_Enabled_NoBurstAfterDelay(string kind)
     {

--- a/QuickTickTests/TimerLifecycleTests.cs
+++ b/QuickTickTests/TimerLifecycleTests.cs
@@ -1,0 +1,312 @@
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using QuickTickLib;
+
+namespace QuickTickTests;
+
+// Lifecycle tests for Start/Stop/Dispose semantics, races and guards across all three timer implementations.
+// Unlike TimerBehaviorTests these are logic tests without tight timing assertions, so the fallback
+// implementation is exercised on every platform here, not only on non-Windows.
+public class TimerLifecycleTests
+{
+    private const double IntervalMs = 15;
+
+    private static IEnumerable<string> AllTimerKinds()
+    {
+        yield return "fallback";
+        yield return "highResolution";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // QuickTickTimerImplementation P/Invokes kernel32 in its constructor and can only run on Windows.
+            // Deliberately last: its Start_AfterDispose failure mode is a process crash which would otherwise
+            // hide the results of the other kinds (see the note on that test).
+            yield return "implementation";
+        }
+    }
+
+    private static IQuickTickTimer CreateTimer(string kind) => kind switch
+    {
+        "implementation" => new QuickTickTimerImplementation(IntervalMs),
+        "fallback"       => new QuickTickTimerFallback(IntervalMs),
+        "highResolution" => new HighResQuickTickTimer(IntervalMs),
+        _                => throw new ArgumentException($"Unknown timer kind: {kind}", nameof(kind))
+    };
+
+    private static Thread? GetWorkerThread(IQuickTickTimer timer) => timer switch
+    {
+        QuickTickTimerImplementation impl => impl.WorkerThreadForTests,
+        QuickTickTimerFallback fallback   => fallback.WorkerThreadForTests,
+        HighResQuickTickTimer highRes     => highRes.WorkerThreadForTests,
+        _                                 => throw new ArgumentException($"Unknown timer type: {timer.GetType()}", nameof(timer))
+    };
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void MultipleStops_DoNotThrow(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        timer.Start();
+        timer.Stop();
+        timer.Stop();
+        timer.Stop();
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    [Platform(Exclude = "MacOsX", Reason = "the fire-count range needs predictable timing which macOS does not provide")]
+    public void MultipleStarts_AreIgnored(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.Elapsed += (_, _) => count++;
+
+        timer.Start();
+        var workerAfterFirstStart = GetWorkerThread(timer);
+        Assert.That(workerAfterFirstStart, Is.Not.Null, $"{kind}: Start() should have spawned a worker thread");
+
+        timer.Start();
+        timer.Start();
+        timer.Start();
+        timer.Start();
+
+        var workerAfterMultipleStarts = GetWorkerThread(timer);
+        Assert.That(ReferenceEquals(workerAfterFirstStart, workerAfterMultipleStarts), Is.True, $"{kind}: subsequent Start() calls replaced the worker thread instead of being ignored");
+        Assert.That(workerAfterFirstStart!.IsAlive, Is.True, $"{kind}: subsequent Start() calls killed the running worker thread");
+
+        Thread.Sleep(500); // Run for ~500ms
+        timer.Stop();
+
+        Assert.That(count, Is.InRange(14, 37)); // One timer should run only, still expect ~32 fires
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void StartAfterStop_FiresAgain(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var count = 0;
+        timer.Elapsed += (_, _) => count++;
+
+        timer.Start();
+        Thread.Sleep(100);
+        timer.Stop();
+        var countFirstRun = count;
+        Assert.That(countFirstRun, Is.GreaterThan(0), $"{kind}: expected fires during first run");
+
+        timer.Start();
+        Thread.Sleep(100);
+        timer.Stop();
+        Assert.That(count, Is.GreaterThan(countFirstRun), $"{kind}: expected fires during second run");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void StopFromHandler_DoesNotDeadlock(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var done = new ManualResetEventSlim(false);
+        timer.Elapsed += (sender, _) =>
+        {
+            ((IQuickTickTimer)sender!).Stop();
+            done.Set();
+        };
+        timer.Start();
+        Assert.That(done.Wait(TimeSpan.FromMilliseconds(200)), Is.True, $"{kind}: Stop() from handler deadlocked or timed out");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void AutoResetFalse_StartFromHandler_RestartsTimer(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var fireCount = 0;
+        var secondFired = new ManualResetEventSlim(false);
+
+        timer.AutoReset = false;
+        timer.Elapsed += (sender, _) =>
+        {
+            fireCount++;
+            if (fireCount == 1)
+            {
+                ((IQuickTickTimer)sender!).Start();
+            }
+            else
+            {
+                secondFired.Set();
+            }
+        };
+
+        timer.Start();
+        Assert.That(secondFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True, $"{kind}: Start() from AutoReset=false handler should restart the timer");
+        timer.Stop();
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Stop_BlocksUntilCurrentHandlerCompletes(string kind)
+    {
+        using var timer = CreateTimer(kind);
+        var handlerStarted  = new ManualResetEventSlim(false);
+        var handlerFinished = new ManualResetEventSlim(false);
+
+        timer.Elapsed += (_, _) =>
+        {
+            handlerStarted.Set();
+            Thread.Sleep(150);
+            handlerFinished.Set();
+        };
+
+        timer.Start();
+        Assert.That(handlerStarted.Wait(TimeSpan.FromMilliseconds(500)), Is.True, "handler should start within 500 ms");
+
+        timer.Stop();
+        Assert.That(handlerFinished.IsSet, Is.True, $"{kind}: Stop() must block until the handler completes (thread join)");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Dispose_StopsTimer(string kind)
+    {
+        var timer = CreateTimer(kind);
+        var count = 0;
+        var firstFired = new ManualResetEventSlim(false);
+        timer.Elapsed += (_, _) => { count++; firstFired.Set(); };
+        timer.Start();
+        Assert.That(firstFired.Wait(TimeSpan.FromMilliseconds(500)), Is.True);
+
+        var workerThread = GetWorkerThread(timer);
+        Assert.That(workerThread, Is.Not.Null, $"{kind}: Start() should have spawned a worker thread");
+
+        timer.Dispose();
+        var countAtDispose = count;
+        Thread.Sleep(150);
+        Assert.That(count, Is.EqualTo(countAtDispose));
+
+        Assert.That(workerThread!.IsAlive, Is.False, $"{kind}: Dispose() left the worker thread running");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Stop_RacingStopCalledFromHandler_DoesNotDeadlock(string kind)
+    {
+        // Deterministic repro of the deadlock: thread A calls Stop(), takes the state lock and blocks in
+        // the worker join; meanwhile the worker is inside the Elapsed handler and calls Stop() itself,
+        // which blocks on the state lock held by A. A joins a thread that waits on A's lock forever.
+        var timer = CreateTimer(kind);
+        var inHandler = new ManualResetEventSlim(false);
+        var handlerStopReturned = new ManualResetEventSlim(false);
+        var firstCall = 1;
+
+        timer.Elapsed += (sender, _) =>
+        {
+            if (Interlocked.Exchange(ref firstCall, 0) == 0)
+            {
+                return;
+            }
+
+            inHandler.Set();
+            Thread.Sleep(150); // Give the foreign thread time to enter Stop() and block in the worker join
+            ((IQuickTickTimer)sender!).Stop();
+            handlerStopReturned.Set();
+        };
+
+        timer.Start();
+        Assert.That(inHandler.Wait(TimeSpan.FromMilliseconds(500)), Is.True, $"{kind}: timer did not fire");
+
+        // The timer is passed as task state instead of being captured: the closure would otherwise be flagged
+        // for capturing a variable that is disposed in the outer scope
+        var foreignStop = Task.Factory.StartNew(state => ((IQuickTickTimer)state!).Stop(), timer);
+
+        Assert.That(foreignStop.Wait(TimeSpan.FromSeconds(3)), Is.True, $"{kind}: Stop() deadlocked against Stop() called from the Elapsed handler");
+        Assert.That(handlerStopReturned.Wait(TimeSpan.FromSeconds(1)), Is.True, $"{kind}: Stop() called from the handler never returned");
+
+        // No 'using': disposing a deadlocked timer would hang the test on failure, so only dispose on success
+        timer.Dispose();
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Start_AfterDispose_ThrowsObjectDisposedException(string kind)
+    {
+        // NOTE while this test is red: for "implementation" it does not merely fail — the started worker
+        // thread hits the disposed timer handle and the unhandled exception terminates the whole test
+        // process. That process crash is exactly the bug this test guards against. Run it isolated via
+        // --filter until the fix is in.
+        var timer = CreateTimer(kind);
+        timer.Start();
+        timer.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(timer.Start, $"{kind}: Start() after Dispose() must throw synchronously");
+
+        var worker = GetWorkerThread(timer);
+        Assert.That(worker is { IsAlive: true }, Is.False, $"{kind}: Start() after Dispose() spawned or left a live worker thread");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void StopAndDispose_AfterDispose_AreNoOps(string kind)
+    {
+        var timer = CreateTimer(kind);
+        timer.Start();
+        timer.Dispose();
+
+        Assert.DoesNotThrow(timer.Stop, $"{kind}: Stop() on a disposed timer must be a silent no-op");
+        Assert.DoesNotThrow(timer.Dispose, $"{kind}: double Dispose() must be a silent no-op");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Dispose_FromHandler_CompletesAndWorkerExits(string kind)
+    {
+        var timer = CreateTimer(kind);
+        var disposedFromHandler = new ManualResetEventSlim(false);
+        var worker = new Thread?[1];
+
+        timer.Elapsed += (sender, _) =>
+        {
+            if (disposedFromHandler.IsSet)
+            {
+                return;
+            }
+
+            var self = (IQuickTickTimer)sender!;
+            worker[0] = GetWorkerThread(self);
+            self.Dispose();
+            disposedFromHandler.Set();
+        };
+
+        timer.Start();
+        Assert.That(disposedFromHandler.Wait(TimeSpan.FromMilliseconds(500)), Is.True, $"{kind}: Dispose() from the handler did not complete");
+
+        Assert.That(worker[0], Is.Not.Null, $"{kind}: worker thread was not captured in the handler");
+        var workerExited = SpinWait.SpinUntil(() => !worker[0]!.IsAlive, TimeSpan.FromSeconds(1));
+        Assert.That(workerExited, Is.True, $"{kind}: worker thread did not exit after Dispose() from the handler");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void ConcurrentStartStop_FromTwoThreads_TimerRemainsFunctional(string kind)
+    {
+        // Guards the Stop() teardown against Start() sneaking in mid-teardown (two workers sharing one timer)
+        var timer = CreateTimer(kind);
+
+        // The timer is passed as task state instead of being captured, see Stop_RacingStopCalledFromHandler_DoesNotDeadlock
+        var end = DateTime.UtcNow.AddMilliseconds(300);
+        var starter = Task.Factory.StartNew(state => { while (DateTime.UtcNow < end) { ((IQuickTickTimer)state!).Start(); } }, timer);
+        var stopper = Task.Factory.StartNew(state => { while (DateTime.UtcNow < end) { ((IQuickTickTimer)state!).Stop(); } }, timer);
+
+        Assert.That(Task.WaitAll([starter, stopper], TimeSpan.FromSeconds(10)), Is.True, $"{kind}: concurrent Start()/Stop() hammering hung");
+
+        timer.Stop();
+        var fired = new ManualResetEventSlim(false);
+        timer.Elapsed += (_, _) => fired.Set();
+        timer.Start();
+        Assert.That(fired.Wait(TimeSpan.FromMilliseconds(500)), Is.True, $"{kind}: timer no longer fires after concurrent Start()/Stop() hammering");
+
+        // No 'using': the hammering tasks only end via the assert timeout when they hang, in which case
+        // disposing the timer would hang the test as well, so only dispose on success
+        timer.Dispose();
+    }
+
+    [Test]
+    public void Fallback_ElapsedCallbackRacingStop_DoesNotThrow()
+    {
+        // System.Timers.Timer can still deliver a queued callback after Stop(). In production that callback
+        // runs inside System.Timers.Timer, which silently swallows exceptions from Elapsed handlers — this
+        // calls the callback directly so a throw actually surfaces.
+        using var timer = new QuickTickTimerFallback(IntervalMs);
+        timer.Start();
+        timer.Stop(); // Calls CompleteAdding() on the event queue
+        
+        // ReSharper disable once AccessToDisposedClosure
+        Assert.DoesNotThrow(() => timer.OnElapsedInternal(null, null!), "fallback: the timer callback must tolerate racing Stop()");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ Initializes a new instance of the `QuickTickTimer` class with the specified inte
 - `ArgumentOutOfRangeException`: Thrown if `interval` is outside the valid range:
     - For QuickTick: must be ≥ 0.5 milliseconds and ≤ int.MaxValue milliseconds
     - For Fallback: must be ≥ 1 millisecond and ≤ int.MaxValue milliseconds
-- `InvalidOperationException`: Thrown if system API calls fail during initialization.
 - `PlatformNotSupportedException`: Throw if you try to run QuickTickLib under windows versions below version 10 Build 1803.
 
 #### QuickTickTimer(TimeSpan interval)
@@ -211,7 +210,6 @@ to create a timer with sub millisecond timing you would need to create the timeS
 - `ArgumentOutOfRangeException`: Thrown if `interval` is outside the valid range:
     - For QuickTick: must be ≥ 0.5 milliseconds and ≤ int.MaxValue milliseconds
     - For Fallback: must be ≥ 1 millisecond and ≤ int.MaxValue milliseconds
-- `InvalidOperationException`: Thrown if system API calls fail during initialization.
 - `PlatformNotSupportedException`: Throw if you try to run QuickTickLib under windows versions below version 10 Build 1803.
 
 ### Properties
@@ -283,11 +281,13 @@ Gets or sets whether the timer should skip missed ticks. Default is false.
 public void Start()
 ```
 
-Starts the timer.
+Starts the timer. Each start creates the resources the timer run needs (worker thread and, where the
+QuickTick implementation is used, the kernel timer); they are released again when the run ends.
 
 ##### Exceptions
 
-- `InvalidOperationException`: Thrown if system API calls fail when setting the timer.
+- `InvalidOperationException`: Thrown if creating the underlying kernel timer fails. Only applies where the QuickTick implementation is used; the fallback implementation creates no kernel objects.
+- `ObjectDisposedException`: Thrown if the timer has already been disposed. A stopped timer can be restarted, a disposed one cannot.
 
 #### Stop()
 
@@ -358,6 +358,13 @@ Implements `IDisposable`, `IQuickTickTimer`
 #### Priority
 
 This timer always starts with `ThreadPriority.Highest`.
+
+#### Start()
+
+Behaves as documented for `QuickTickTimer`, including the possible exceptions: on Windows each run caches
+one kernel timer for its sleep phase, so `Start()` can throw an `InvalidOperationException` if creating it
+fails. On platforms without waitable timers no kernel objects are created and sleeping falls back to
+`Thread.Sleep()`.
 
 #### IsQuickTickUsed
 


### PR DESCRIPTION
Fixes #62 

updated documentation; new tests; all now runs; same performance
handels are chached now for for highres sleep (discussion 46)

Setting timer inetrval doesnt throw object dsipose but thats okay only start does after disposed