### PR TITLE
Hybrid sleep

### DIFF
--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -10,8 +10,8 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     private volatile bool _running;
     private volatile bool _skipMissedIntervals;
     private double _intervalMs;
-    private volatile float _sleepThreshold = 1.5f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensively testing with the TimingReportGenerator
-    private volatile float _yieldThreshold = 0.75f; // This is a value that works on Ubuntu and Windows with appropriate power settings. Getting this value was done by extensively testing with the TimingReportGenerator
+    private volatile float _sleepThreshold = HighResTimerDefaults.SleepThreshold;
+    private volatile float _yieldThreshold = HighResTimerDefaults.YieldThreshold;
     private long _intervalTicks;
     private ThreadPriority _threadPriority = ThreadPriority.Highest;
     private HighResQuickTickTimerRun? _currentRun;
@@ -154,6 +154,7 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
 
                 var run = _currentRun!; // While _running is true a current run always exists
                 run.CancellationTokenSource.Cancel();
+                run.StopEvent.Set(); // Wake the worker thread out of its long sleep phase
                 _currentRun = null;
 
                 if (Thread.CurrentThread == run.Thread)
@@ -203,7 +204,18 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
                         break;
                     }
 
-                    if (diffTicks >= QuickTickHelper.StopwatchTicksPerMillisecond * _sleepThreshold)
+                    var sleepThresholdTicks = QuickTickHelper.StopwatchTicksPerMillisecond * _sleepThreshold;
+
+                    // The extra millisecond keeps the long sleep from ever being shorter than the whole-millisecond
+                    // resolution of its event-wait fallback; below the line the short phases finish the job as before
+                    if (diffTicks >= 2 * sleepThresholdTicks + QuickTickHelper.StopwatchTicksPerMillisecond)
+                    {
+                        // Sleep most of the remaining time in one interruptible block, waking two SleepThresholds
+                        // early so the sleep/yield/spin ladder below handles the precise part. Overshoot is safe:
+                        // this loop re-measures the remaining time on every pass.
+                        SleepUntilNearDeadline(run, diffTicks - (long)(2 * sleepThresholdTicks));
+                    }
+                    else if (diffTicks >= sleepThresholdTicks)
                     {
                         QuickTickTiming.MinimalSleep(run.Handles);
                     }
@@ -287,6 +299,23 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
             // Outside the lock on purpose: once the run is unlinked Stop() can no longer reach these objects,
             // so disposing them cannot race the Cancel() call that only targets the current run
             run.Dispose();
+        }
+    }
+
+    private static void SleepUntilNearDeadline(HighResQuickTickTimerRun run, long stopwatchTicksToSleep)
+    {
+        if (run.LongSleepWaitHandles != null)
+        {
+            // One shot of the run's cached kernel timer; the stop event in the wait handles wakes it early
+            QuickTickTiming.InterruptibleQuickTickSleep(run.Handles!, run.LongSleepWaitHandles, QuickTickHelper.StopwatchTicksToTimeSpanTicks(stopwatchTicksToSleep));
+        }
+        else
+        {
+            // No kernel timer on this platform: a timed event wait is the interruptible long sleep. Its whole-
+            // millisecond resolution and Thread.Sleep-like overshoot are what the SleepThreshold defaults of the
+            // non-QuickTick tiers must cover.
+            var sleepTimeMs = (int)(stopwatchTicksToSleep / QuickTickHelper.StopwatchTicksPerMillisecond);
+            run.StopEvent.WaitOne(sleepTimeMs);
         }
     }
 

--- a/QuickTickLib/HighResQuickTickTimer.cs
+++ b/QuickTickLib/HighResQuickTickTimer.cs
@@ -66,7 +66,8 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
     /// <summary>
     /// Defines the minimum time that must be available towards the next timer iteration for the thread to sleep.
     /// Increasing this time can lead to better timing but increases CPU usage as the code will Yield or SpinWait instead.
-    /// Must be at least 1.0 and at most int.MaxValue.
+    /// Must be at least 0.5 and at most int.MaxValue. Values below 1.0 only make sense where the minimal sleep
+    /// is precise (Windows waitable timers, Linux clock_nanosleep); on the Thread.Sleep fallback they cause late ticks.
     /// YieldThreshold must always be less than or equal to SleepThreshold.
     /// Setting SleepThreshold to int.MaxValue will basically disable sleeping the thread and the timer will Yield or SpinWait the thread instead.
     /// </summary>
@@ -75,9 +76,9 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
         get => _sleepThreshold;
         set
         {
-            if (value < 1.0 || value > int.MaxValue || double.IsNaN(value))
+            if (value < 0.5 || value > int.MaxValue || double.IsNaN(value))
             {
-                throw new ArgumentOutOfRangeException(nameof(value), "SleepThreshold must be greater than or equal to 1.0 and smaller than int.MaxValue.");
+                throw new ArgumentOutOfRangeException(nameof(value), "SleepThreshold must be greater than or equal to 0.5 and smaller than int.MaxValue.");
             }
 
             if (_yieldThreshold > value)
@@ -205,15 +206,19 @@ public sealed class HighResQuickTickTimer : IQuickTickTimer
                     }
 
                     var sleepThresholdTicks = QuickTickHelper.StopwatchTicksPerMillisecond * _sleepThreshold;
+                    // The margin floor protects sub-millisecond thresholds: the long sleep mechanism can overshoot
+                    // far more than the chunk sleep, so it must never be asked to wake closer to the deadline than
+                    // its own overshoot (see HighResTimerDefaults.LongSleepWakeMarginMs)
+                    var longSleepWakeTicks = Math.Max(2 * sleepThresholdTicks, QuickTickHelper.StopwatchTicksPerMillisecond * HighResTimerDefaults.LongSleepWakeMarginMs);
 
                     // The extra millisecond keeps the long sleep from ever being shorter than the whole-millisecond
                     // resolution of its event-wait fallback; below the line the short phases finish the job as before
-                    if (diffTicks >= 2 * sleepThresholdTicks + QuickTickHelper.StopwatchTicksPerMillisecond)
+                    if (diffTicks >= longSleepWakeTicks + QuickTickHelper.StopwatchTicksPerMillisecond)
                     {
-                        // Sleep most of the remaining time in one interruptible block, waking two SleepThresholds
-                        // early so the sleep/yield/spin ladder below handles the precise part. Overshoot is safe:
-                        // this loop re-measures the remaining time on every pass.
-                        SleepUntilNearDeadline(run, diffTicks - (long)(2 * sleepThresholdTicks));
+                        // Sleep most of the remaining time in one interruptible block, waking early enough that the
+                        // sleep/yield/spin ladder below handles the precise part. Overshoot is safe: this loop
+                        // re-measures the remaining time on every pass.
+                        SleepUntilNearDeadline(run, diffTicks - (long)longSleepWakeTicks);
                     }
                     else if (diffTicks >= sleepThresholdTicks)
                     {

--- a/QuickTickLib/HighResQuickTickTimerRun.cs
+++ b/QuickTickLib/HighResQuickTickTimerRun.cs
@@ -1,20 +1,33 @@
 namespace QuickTickLib;
 
 // Bundles everything a single high-res timer run owns: the cached sleep timer handles (where the platform
-// has them), the cancellation source and the worker thread. Created by Start(); disposed by the worker
-// thread itself on exit, after it unlinked the run under the state lock so Stop() can no longer reach
-// these objects. Unlike QuickTickTimerRun there is no stop event: the spin/sleep/yield loop never blocks
-// for longer than one MinimalSleep, so polling the cancellation token is enough to stop promptly.
+// has them), the stop signal, the cancellation source and the worker thread. Created by Start(); disposed
+// by the worker thread itself on exit, after it unlinked the run under the state lock so Stop() can no
+// longer reach these objects. The stop event only wakes the long sleep-until-near-deadline phase early;
+// the short sleep/yield/spin phases never block longer than one MinimalSleep and just poll the token.
 internal sealed class HighResQuickTickTimerRun : IDisposable
 {
     // Null where the platform has no Win32 waitable timers (this timer runs everywhere);
-    // MinimalSleep falls back to Thread.Sleep on its own then
+    // the sleep phases fall back to clock_nanosleep or Thread.Sleep on their own then
     public readonly QuickTickHandleResources? Handles = QuickTickTiming.IsQuickTickSupported ? new QuickTickHandleResources() : null;
+    public readonly ManualResetEvent StopEvent = new(false);
     public readonly CancellationTokenSource CancellationTokenSource = new();
     public Thread Thread = null!; // Set by Start() right after construction; the thread's loop closes over this run
 
+    // Prebuilt for the long sleep phase so the timer loop stays allocation-free; null without a kernel timer
+    public readonly WaitHandle[]? LongSleepWaitHandles;
+
+    public HighResQuickTickTimerRun()
+    {
+        if (Handles != null)
+        {
+            LongSleepWaitHandles = new[] { Handles.TimerWaitHandle, StopEvent };
+        }
+    }
+
     public void Dispose()
     {
+        StopEvent.Dispose();
         Handles?.Dispose();
         // The CancellationTokenSource is deliberately not disposed: without CancelAfter() and without accessing
         // its WaitHandle property it creates no unmanaged resources, so the GC reclaims it on its own. Disposing

--- a/QuickTickLib/HighResTimerDefaults.cs
+++ b/QuickTickLib/HighResTimerDefaults.cs
@@ -8,6 +8,12 @@ internal static class HighResTimerDefaults
     internal static readonly float SleepThreshold;
     internal static readonly float YieldThreshold;
 
+    // Minimum time before the deadline at which the long sleep-until-near-deadline block must wake, as a floor
+    // under 2 x SleepThreshold. The long sleep mechanism is not the chunk sleep mechanism: where there is no
+    // kernel timer the long block is a timed event wait with Thread.Sleep-like overshoot, so with sub-millisecond
+    // thresholds 2 x SleepThreshold alone would be thinner than that overshoot and ticks would fire late.
+    internal static readonly float LongSleepWakeMarginMs;
+
     static HighResTimerDefaults()
     {
         if (QuickTickTiming.IsQuickTickSupported)
@@ -16,13 +22,14 @@ internal static class HighResTimerDefaults
             // under 1.5 ms in over 99% of all cases (with appropriate power settings)
             SleepThreshold = 1.5f;
             YieldThreshold = 0.75f;
+            LongSleepWakeMarginMs = 0f; // The long sleep uses the same high-resolution kernel timer, 2 x SleepThreshold covers it
         }
         else if (QuickTickTiming.IsClockNanosleepSupported)
         {
-            // clock_nanosleep typically overshoots by only tens of microseconds on default kernels;
-            // provisional values until validated with TimingReportGenerator runs on Linux
-            SleepThreshold = 1.0f;
-            YieldThreshold = 0.5f;
+            // From Linux testing with the 250 µs clock_nanosleep chunk; provisional until validated with TimingReportGenerator runs
+            SleepThreshold = 0.5f;
+            YieldThreshold = 0.3f;
+            LongSleepWakeMarginMs = 3f; // Timed event waits stayed under 2 ms in Linux testing; 3 ms keeps a full millisecond of slack
         }
         else
         {
@@ -30,6 +37,7 @@ internal static class HighResTimerDefaults
             // from the deadline; 15 ms matches the guidance the README previously gave for manual tuning
             SleepThreshold = 15f;
             YieldThreshold = 0.75f;
+            LongSleepWakeMarginMs = 15f; // Same overshoot class as the sleep itself
         }
     }
 }

--- a/QuickTickLib/HighResTimerDefaults.cs
+++ b/QuickTickLib/HighResTimerDefaults.cs
@@ -1,0 +1,35 @@
+namespace QuickTickLib;
+
+// Default spin/sleep thresholds for HighResQuickTickTimer, chosen once per process for the sleep capability
+// tier the platform lands on. The tiers matter because SleepThreshold must cover the worst-case overshoot of
+// the tier's sleep mechanism; users can still override both values through the timer's properties.
+internal static class HighResTimerDefaults
+{
+    internal static readonly float SleepThreshold;
+    internal static readonly float YieldThreshold;
+
+    static HighResTimerDefaults()
+    {
+        if (QuickTickTiming.IsQuickTickSupported)
+        {
+            // Windows waitable timers: extensive TimingReportGenerator testing showed MinimalSleep stays
+            // under 1.5 ms in over 99% of all cases (with appropriate power settings)
+            SleepThreshold = 1.5f;
+            YieldThreshold = 0.75f;
+        }
+        else if (QuickTickTiming.IsClockNanosleepSupported)
+        {
+            // clock_nanosleep typically overshoots by only tens of microseconds on default kernels;
+            // provisional values until validated with TimingReportGenerator runs on Linux
+            SleepThreshold = 1.0f;
+            YieldThreshold = 0.5f;
+        }
+        else
+        {
+            // Thread.Sleep tier (e.g. macOS, where Sleep(1) can take 10+ ms): sleeping is only worth it far
+            // from the deadline; 15 ms matches the guidance the README previously gave for manual tuning
+            SleepThreshold = 15f;
+            YieldThreshold = 0.75f;
+        }
+    }
+}

--- a/QuickTickLib/LinuxInterop.cs
+++ b/QuickTickLib/LinuxInterop.cs
@@ -1,0 +1,117 @@
+using System.Runtime.InteropServices;
+
+namespace QuickTickLib;
+
+internal static partial class LinuxInterop
+{
+    private const string LibcDll = "libc";
+
+    private const int ClockMonotonic = 1; // CLOCK_MONOTONIC; same value on all Linux architectures
+    private const int TimerAbstime = 1; // TIMER_ABSTIME flag for clock_nanosleep: request is an absolute deadline
+    private const int Eintr = 4; // Interrupted by a signal; the sleep must simply be retried
+    private const long NanosecondsPerSecond = 1_000_000_000;
+
+    // tv_sec (time_t) and tv_nsec are C longs in the default ABI: 8 bytes on 64-bit Linux but 4 bytes on
+    // 32-bit targets like linux-arm, so nint is the only field type that matches both layouts
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Timespec
+    {
+        public nint tv_sec;
+        public nint tv_nsec;
+    }
+
+#if NET
+    [LibraryImport(LibcDll, EntryPoint = "clock_gettime", SetLastError = true)]
+    private static partial int ClockGettime(
+        int clockId, // The clock to read // CLOCK_MONOTONIC here, immune to wall-clock adjustments
+        ref Timespec tp // Receives the current time of that clock
+    );
+
+    // No SetLastError: unlike most libc functions clock_nanosleep does not use errno, it returns the error number directly
+    [LibraryImport(LibcDll, EntryPoint = "clock_nanosleep")]
+    private static partial int ClockNanosleep(
+        int clockId, // The clock to sleep against // CLOCK_MONOTONIC here
+        int flags, // TIMER_ABSTIME to treat request as an absolute deadline // Makes EINTR retries lose no time
+        ref Timespec request, // The deadline to sleep until
+        IntPtr remain // Receives the remaining time when interrupted // Not needed with TIMER_ABSTIME, retry with the same deadline instead
+    );
+#else
+    [DllImport(LibcDll, EntryPoint = "clock_gettime", SetLastError = true)]
+    private static extern int ClockGettime(
+        int clockId, // The clock to read // CLOCK_MONOTONIC here, immune to wall-clock adjustments
+        ref Timespec tp // Receives the current time of that clock
+    );
+
+    // No SetLastError: unlike most libc functions clock_nanosleep does not use errno, it returns the error number directly
+    [DllImport(LibcDll, EntryPoint = "clock_nanosleep")]
+    private static extern int ClockNanosleep(
+        int clockId, // The clock to sleep against // CLOCK_MONOTONIC here
+        int flags, // TIMER_ABSTIME to treat request as an absolute deadline // Makes EINTR retries lose no time
+        ref Timespec request, // The deadline to sleep until
+        IntPtr remain // Receives the remaining time when interrupted // Not needed with TIMER_ABSTIME, retry with the same deadline instead
+    );
+#endif
+
+    // A capability probe instead of an OS-name check: every Linux able to load a supported .NET runtime has
+    // clock_nanosleep in libc (glibc since 2.17 — the runtime's own minimum —, musl and bionic always had it)
+    // and FreeBSD comes along for free, while macOS lacks the symbol entirely. Probing once here keeps a missing
+    // symbol from surfacing later as a DllNotFoundException on a timer worker thread.
+    internal static bool PlatformSupportsPreciseSleep()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return false;
+        }
+
+        try
+        {
+            // An absolute deadline of 0 lies in the past, so this returns immediately; a zero result proves
+            // both that the symbol resolves and that the monotonic clock accepts sleep requests
+            var deadline = default(Timespec);
+            return ClockNanosleep(ClockMonotonic, TimerAbstime, ref deadline, IntPtr.Zero) == 0;
+        }
+        catch (DllNotFoundException)
+        {
+            return false;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The ticksToSleep must be specified in <see cref="TimeSpan"/> ticks (100-nanosecond intervals),
+    /// not <see cref="System.Diagnostics.Stopwatch"/> ticks, same as QuickTickTiming.QuickTickSleep.
+    /// </summary>
+    internal static void PreciseSleep(long ticksToSleep)
+    {
+        var now = default(Timespec);
+        if (ClockGettime(ClockMonotonic, ref now) != 0)
+        {
+            // Cannot realistically fail for a probed, always-present clock; fail fast like SetWaitableTimer failures
+            throw new InvalidOperationException($"clock_gettime failed: {Marshal.GetLastWin32Error()}");
+        }
+
+        // Sleep to an absolute deadline on the monotonic clock: a retry after EINTR reuses the same deadline
+        // and therefore loses no time, unlike relative sleeps which would restart the full duration
+        var totalNanoseconds = now.tv_nsec + ticksToSleep % TimeSpan.TicksPerSecond * 100;
+        var deadline = new Timespec
+        {
+            tv_sec = (nint)(now.tv_sec + ticksToSleep / TimeSpan.TicksPerSecond + totalNanoseconds / NanosecondsPerSecond),
+            tv_nsec = (nint)(totalNanoseconds % NanosecondsPerSecond)
+        };
+
+        int result;
+        do
+        {
+            result = ClockNanosleep(ClockMonotonic, TimerAbstime, ref deadline, IntPtr.Zero);
+        } while (result == Eintr);
+
+        if (result != 0)
+        {
+            // Cannot realistically fail with a probed clock and valid arguments; fail fast like SetWaitableTimer failures
+            throw new InvalidOperationException($"clock_nanosleep failed: {result}");
+        }
+    }
+}

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -11,6 +11,9 @@ public static class QuickTickTiming
     // Settable in tests (InternalsVisibleTo("QuickTickTests")) to exercise the Thread.Sleep/Task.Delay fallback path
     internal static bool IsQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
 
+    // Settable in tests (InternalsVisibleTo("QuickTickTests")) to exercise the Thread.Sleep fallback tier
+    internal static bool IsClockNanosleepSupported = LinuxInterop.PlatformSupportsPreciseSleep();
+
     // Not async on purpose: usage errors (unsupported platform) should throw synchronously at the call site
     // ReSharper disable once MemberCanBePrivate.Global
     public static Task Delay(int millisecondsDelay, CancellationToken cancellationToken = default)
@@ -72,17 +75,24 @@ public static class QuickTickTiming
     // after the caller created its run); the caller keeps ownership and disposes them
     internal static void MinimalSleep(QuickTickHandleResources? cachedHandles)
     {
-        if (!IsQuickTickSupported)
+        if (IsQuickTickSupported)
         {
-            Thread.Sleep(1);
+            if (cachedHandles != null)
+            {
+                QuickTickSleep(cachedHandles, FourHundredMicroSecondInTicks);
+            }
+            else
+            {
+                QuickTickSleep(FourHundredMicroSecondInTicks);
+            }
         }
-        else if (cachedHandles != null)
+        else if (IsClockNanosleepSupported)
         {
-            QuickTickSleep(cachedHandles, FourHundredMicroSecondInTicks);
+            LinuxInterop.PreciseSleep(FourHundredMicroSecondInTicks);
         }
         else
         {
-            QuickTickSleep(FourHundredMicroSecondInTicks);
+            Thread.Sleep(1);
         }
     }
 
@@ -106,5 +116,20 @@ public static class QuickTickTiming
         }
 
         handles.TimerWaitHandle.WaitOne();
+    }
+
+    // Interruptible variant for the long sleep-until-near-deadline phase of HighResQuickTickTimer:
+    // waitHandles must contain the wait handle of handles' timer plus the event that wakes the sleep early.
+    // Waking early is safe because SetWaitableTimer resets a still-pending timer signal on the next call.
+    internal static void InterruptibleQuickTickSleep(QuickTickHandleResources handles, WaitHandle[] waitHandles, long tickToSleep)
+    {
+        var sleepTimeTicks = -tickToSleep; // Negative means relative time
+
+        if (!Win32Interop.SetWaitableTimer(handles.TimerHandle, ref sleepTimeTicks, 0, IntPtr.Zero, IntPtr.Zero, false))
+        {
+            throw new InvalidOperationException($"SetWaitableTimer failed: {Marshal.GetLastWin32Error()}");
+        }
+
+        WaitHandle.WaitAny(waitHandles);
     }
 }

--- a/QuickTickLib/QuickTickTiming.cs
+++ b/QuickTickLib/QuickTickTiming.cs
@@ -8,6 +8,9 @@ public static class QuickTickTiming
     // QuickTickSleep expects 100ns (TimeSpan) ticks, same as its other caller Sleep(), so this must be derived from TimeSpan.TicksPerMillisecond
     private const long FourHundredMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.4);
 
+    // clock_nanosleep overshoots by only tens of microseconds, so its chunk can be shorter than the Windows one
+    private const long TwoHundredFiftyMicroSecondInTicks = (long)(TimeSpan.TicksPerMillisecond * 0.25);
+
     // Settable in tests (InternalsVisibleTo("QuickTickTests")) to exercise the Thread.Sleep/Task.Delay fallback path
     internal static bool IsQuickTickSupported = QuickTickHelper.PlatformSupportsQuickTick();
 
@@ -88,7 +91,7 @@ public static class QuickTickTiming
         }
         else if (IsClockNanosleepSupported)
         {
-            LinuxInterop.PreciseSleep(FourHundredMicroSecondInTicks);
+            LinuxInterop.PreciseSleep(TwoHundredFiftyMicroSecondInTicks);
         }
         else
         {

--- a/QuickTickTests/TimerLifecycleTests.cs
+++ b/QuickTickTests/TimerLifecycleTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using NUnit.Framework;
 using QuickTickLib;
@@ -24,11 +25,11 @@ public class TimerLifecycleTests
         }
     }
 
-    private static IQuickTickTimer CreateTimer(string kind) => kind switch
+    private static IQuickTickTimer CreateTimer(string kind, double intervalMs = IntervalMs) => kind switch
     {
-        "implementation" => new QuickTickTimerImplementation(IntervalMs),
-        "fallback"       => new QuickTickTimerFallback(IntervalMs),
-        "highResolution" => new HighResQuickTickTimer(IntervalMs),
+        "implementation" => new QuickTickTimerImplementation(intervalMs),
+        "fallback"       => new QuickTickTimerFallback(intervalMs),
+        "highResolution" => new HighResQuickTickTimer(intervalMs),
         _                => throw new ArgumentException($"Unknown timer kind: {kind}", nameof(kind))
     };
 
@@ -155,6 +156,23 @@ public class TimerLifecycleTests
 
         timer.Stop();
         Assert.That(handlerFinished.IsSet, Is.True, $"{kind}: Stop() must block until the handler completes (thread join)");
+    }
+
+    [TestCaseSource(nameof(AllTimerKinds))]
+    public void Stop_DuringLongWaitForDistantDeadline_ReturnsPromptly(string kind)
+    {
+        // With a 10 s interval the worker sits in its long wait (kernel timer wait, blocking take, or the
+        // high-res timer's sleep-until-near-deadline); Stop() must wake that wait instead of blocking in
+        // the worker join until the full interval runs out
+        using var timer = CreateTimer(kind, 10_000);
+        timer.Start();
+        Thread.Sleep(100); // Let the worker enter its long wait
+
+        var sw = Stopwatch.StartNew();
+        timer.Stop();
+        sw.Stop();
+
+        Assert.That(sw.Elapsed.TotalMilliseconds, Is.LessThan(1000), $"{kind}: Stop() did not interrupt the long wait promptly");
     }
 
     [TestCaseSource(nameof(AllTimerKinds))]

--- a/README.md
+++ b/README.md
@@ -333,6 +333,11 @@ The timer provides the same interface as the normal QuickTickTimer but functions
 and according to the remaining time to the next interval either sleeps, yields the thread or spin waits. It therefore needs more CPU than the regular timer, but
 also has a higher precision in the timing events.
 
+While more than twice the `SleepThreshold` (plus one millisecond) remains until the next interval, the timer sleeps that whole span in a single interruptible block
+instead of many small sleeps: on Windows one shot of the run's cached high-resolution kernel timer, elsewhere a timed wait on the stop event. It wakes two
+`SleepThreshold`s before the deadline and hands over to the usual sleep/yield/spin phases for the precise part, so long intervals no longer cost hundreds of
+wakeups while the timing behavior near the deadline stays unchanged.
+
 This timer fully **supports sub-millisecond intervals on all systems**, as it does not rely on the `System.Timers.Timer` implementation.
 
 > _See `QuickTickTimer` remarks for important details about `Elapsed` event execution, timing constraints, and exception handling._
@@ -377,19 +382,22 @@ the way it sleeps is switched on the different operating systems.
 public double SleepThreshold { get; set }
 ```
 
-Defines the minimum time that must be available towards the next timer iteration for the thread to sleep. Default is 1.5 ms.
+Defines the minimum time that must be available towards the next timer iteration for the thread to sleep.
+The default depends on the sleep mechanism the platform provides: 1.5 ms on Windows (high-resolution waitable timers),
+1.0 ms on Linux (`clock_nanosleep`) and 15 ms where only `Thread.Sleep()` is available (e.g. macOS).
 Increasing this time can lead to better timing but increases CPU usage as the code will Yield or SpinWait instead.
 Must be at least 1.0 and at most int.MaxValue.
 YieldThreshold must always be less than or equal to SleepThreshold.
 Setting SleepThreshold to int.MaxValue will basically disable sleeping the thread and the timer will Yield or SpinWait the thread instead.
 
 > [!Note]
-> If a sleep is to be performed a function called `MinimalSleep` sleep is called. This sleeps for 1 ms using `Thread.Sleep()` under non windows 
-> systems and for 400 µs using a special `QuickTickTiming.QuickTickSleep()` function under windows. Testing for linux and windows showed, 
-> that in both cases the actual sleep time stays under 1.5 ms in over 99% of all cases which is why 1.5 ms is the default sleep time.
-> An even safer value is 2.0 ms as in testing all minimal sleep timings stayed under 2.0 ms for both linux and windows.
-> For systems like macOS where the accuracy of `Thread.Sleep()` is way worse than under linux a good value for the `SleepThreshold` is around 15 ms,
-> although it should be remembered, that this will basically use a full core.
+> If a sleep is to be performed a function called `MinimalSleep` is called. This sleeps for 400 µs using a special `QuickTickTiming.QuickTickSleep()`
+> function under windows, for 400 µs using `clock_nanosleep` on the monotonic clock under linux, and for 1 ms using `Thread.Sleep()` everywhere else.
+> Windows testing showed the actual sleep time stays under 1.5 ms in over 99% of all cases which is why 1.5 ms is the default sleep threshold there;
+> an even safer value is 2.0 ms as in testing all minimal sleep timings stayed under 2.0 ms. `clock_nanosleep` typically overshoots by only tens of
+> microseconds which is why linux defaults to a smaller threshold of 1.0 ms.
+> For systems like macOS where the accuracy of `Thread.Sleep()` is way worse than under linux the `SleepThreshold` defaults to 15 ms,
+> although it should be remembered, that this will basically use a full core while spinning towards the deadline.
 
 > [!Note]
 > Not part of the `IQuickTickTimer` interface; Only available from the class directly

--- a/README.md
+++ b/README.md
@@ -333,10 +333,10 @@ The timer provides the same interface as the normal QuickTickTimer but functions
 and according to the remaining time to the next interval either sleeps, yields the thread or spin waits. It therefore needs more CPU than the regular timer, but
 also has a higher precision in the timing events.
 
-While more than twice the `SleepThreshold` (plus one millisecond) remains until the next interval, the timer sleeps that whole span in a single interruptible block
-instead of many small sleeps: on Windows one shot of the run's cached high-resolution kernel timer, elsewhere a timed wait on the stop event. It wakes two
-`SleepThreshold`s before the deadline and hands over to the usual sleep/yield/spin phases for the precise part, so long intervals no longer cost hundreds of
-wakeups while the timing behavior near the deadline stays unchanged.
+While far enough from the next interval, the timer sleeps most of the remaining span in a single interruptible block instead of many small sleeps: on Windows one
+shot of the run's cached high-resolution kernel timer, elsewhere a timed wait on the stop event. It wakes twice the `SleepThreshold` before the deadline (but never
+closer than a platform-specific margin covering the long sleep's own wake-up overshoot) and hands over to the usual sleep/yield/spin phases for the precise part,
+so long intervals no longer cost hundreds of wakeups while the timing behavior near the deadline stays unchanged.
 
 This timer fully **supports sub-millisecond intervals on all systems**, as it does not rely on the `System.Timers.Timer` implementation.
 
@@ -384,18 +384,19 @@ public double SleepThreshold { get; set }
 
 Defines the minimum time that must be available towards the next timer iteration for the thread to sleep.
 The default depends on the sleep mechanism the platform provides: 1.5 ms on Windows (high-resolution waitable timers),
-1.0 ms on Linux (`clock_nanosleep`) and 15 ms where only `Thread.Sleep()` is available (e.g. macOS).
+0.5 ms on Linux (`clock_nanosleep`) and 15 ms where only `Thread.Sleep()` is available (e.g. macOS).
 Increasing this time can lead to better timing but increases CPU usage as the code will Yield or SpinWait instead.
-Must be at least 1.0 and at most int.MaxValue.
+Must be at least 0.5 and at most int.MaxValue. Values below 1.0 only make sense where the minimal sleep is precise
+(Windows, Linux); on the `Thread.Sleep()` fallback they cause late ticks.
 YieldThreshold must always be less than or equal to SleepThreshold.
 Setting SleepThreshold to int.MaxValue will basically disable sleeping the thread and the timer will Yield or SpinWait the thread instead.
 
 > [!Note]
 > If a sleep is to be performed a function called `MinimalSleep` is called. This sleeps for 400 µs using a special `QuickTickTiming.QuickTickSleep()`
-> function under windows, for 400 µs using `clock_nanosleep` on the monotonic clock under linux, and for 1 ms using `Thread.Sleep()` everywhere else.
+> function under windows, for 250 µs using `clock_nanosleep` on the monotonic clock under linux, and for 1 ms using `Thread.Sleep()` everywhere else.
 > Windows testing showed the actual sleep time stays under 1.5 ms in over 99% of all cases which is why 1.5 ms is the default sleep threshold there;
 > an even safer value is 2.0 ms as in testing all minimal sleep timings stayed under 2.0 ms. `clock_nanosleep` typically overshoots by only tens of
-> microseconds which is why linux defaults to a smaller threshold of 1.0 ms.
+> microseconds which is why linux defaults to a smaller threshold of 0.5 ms (with 0.3 ms as the yield threshold).
 > For systems like macOS where the accuracy of `Thread.Sleep()` is way worse than under linux the `SleepThreshold` defaults to 15 ms,
 > although it should be remembered, that this will basically use a full core while spinning towards the deadline.
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ On older Windows versions, QuickTick cannot function and will throw a PlatformNo
 
 QuickTick falls back to the standard .NET timers, which already provide high precision. All the functions the library provide can be used without needing to change settings.
 
+The `HighResQuickTickTimer` does not use the fallback: on Linux it sleeps via `clock_nanosleep` on the monotonic clock, which overshoots by only tens of microseconds.
+This allows sub-millisecond default thresholds and gives precise timing at low CPU usage.
+
 #### macOS Support
 
 ⚠️ Supported, meaning the timer will run under macOS but the base .Net functions the timer falls back to are not very precise.
 
 See the macOS timing report for more details. 
 
-For best results, use HighResQuickTickTimer with adjusted settings. See macOS timing report Comment. This effectively burns a whole CPU core to hold a precise timing.
+For best results, use HighResQuickTickTimer. Its thresholds default to macOS-suitable values (`SleepThreshold` 15 ms) where no precise sleep mechanism exists,
+see the macOS timing report comment. This effectively burns a whole CPU core to hold a precise timing.
 The timing accuracy of `QuickTickTiming.Sleep()` and `QuickTickTiming.Delay()` match the native .NET function but are imprecise and can't be improved easily.
 
 ## Performance Reports
@@ -328,7 +332,7 @@ Occurs when the timer interval has elapsed.
 
 Namespace: QuickTickLib
 
-This is a high resolution timer based on the `QuickTickTiming.Sleep` function aswell as the HighResTimer by György Kőszeg [found here](https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs).
+This is a high resolution timer based on the sleep mechanisms of `QuickTickTiming` (windows high-resolution waitable timers, `clock_nanosleep` on linux) aswell as the HighResTimer by György Kőszeg [found here](https://github.com/koszeggy/KGySoft.CoreLibraries/blob/master/KGySoft.CoreLibraries/CoreLibraries/HiResTimer.cs).
 The timer provides the same interface as the normal QuickTickTimer but functions completly different internally. In short the timer is a loop that always checks the time
 and according to the remaining time to the next interval either sleeps, yields the thread or spin waits. It therefore needs more CPU than the regular timer, but
 also has a higher precision in the timing events.
@@ -343,11 +347,11 @@ This timer fully **supports sub-millisecond intervals on all systems**, as it do
 > _See `QuickTickTimer` remarks for important details about `Elapsed` event execution, timing constraints, and exception handling._
 
 This timer is conceptually similar to the HighResTimer by György Kőszeg, but uses the QuickTickTiming methods to reduce CPU usage when possible:
-- For intervals below ~2.5 ms, it behaves very similarly in both timing accuracy and CPU usage, relying primarily on spin-waiting.
-- For intervals above ~2.5 ms, it introduces controlled sleep and yield phases, significantly reducing CPU usage while still maintaining very stable timing behavior.
+- For intervals below roughly the `SleepThreshold` (~2.5 ms on Windows, ~1 ms on Linux), it behaves very similarly in both timing accuracy and CPU usage, relying primarily on spin-waiting.
+- For larger intervals, it introduces controlled sleep and yield phases, significantly reducing CPU usage while still maintaining very stable timing behavior.
 
 > [!Note]
-> For very small intervals (below ~2.5 ms), the timer does not sleep and instead spin-waits continuously.
+> For very small intervals (below roughly the `SleepThreshold`), the timer does not sleep and instead spin-waits continuously.
 > This will effectively utilize an entire CPU core.
 
 ```csharp
@@ -367,9 +371,9 @@ This timer always starts with `ThreadPriority.Highest`.
 #### Start()
 
 Behaves as documented for `QuickTickTimer`, including the possible exceptions: on Windows each run caches
-one kernel timer for its sleep phase, so `Start()` can throw an `InvalidOperationException` if creating it
-fails. On platforms without waitable timers no kernel objects are created and sleeping falls back to
-`Thread.Sleep()`.
+one kernel timer for its sleep phases, so `Start()` can throw an `InvalidOperationException` if creating it
+fails. On platforms without waitable timers no kernel objects are created and sleeping uses `clock_nanosleep`
+(Linux) or falls back to `Thread.Sleep()`.
 
 #### IsQuickTickUsed
 
@@ -409,7 +413,8 @@ Setting SleepThreshold to int.MaxValue will basically disable sleeping the threa
 public double YieldThreshold { get; set }
 ```
 
-Defines the minimum time that must be available towards the next timer iteration to yield the thread. Default is 0.75 ms.
+Defines the minimum time that must be available towards the next timer iteration to yield the thread.
+The default matches the platform's `SleepThreshold` tier: 0.75 ms on Windows and on the `Thread.Sleep()` fallback, 0.3 ms on Linux.
 Increasing this time can lead to better timing but increases CPU usage as the code will SpinWait instead.
 Must be at least 0.0 and at most the value of SleepThreshold. 
 Setting YieldThreshold equal to SleepThreshold disables yielding (goes directly to spin wait).


### PR DESCRIPTION
  ▎ Implements the sleep rework for the HighResQuickTickTimer: while more than max(2×SleepThreshold, platform wake margin) + 1 ms remains, the timer sleeps in one interruptible block (cached kernel timer on Windows, timed stop-event wait elsewhere) instead of hundreds of chunk sleeps. On Linux,
  ▎ MinimalSleep now uses clock_nanosleep on the monotonic clock (250 µs chunks, capability-probed once), enabling sub-millisecond default thresholds (0.5/0.3). Defaults are per capability tier; macOS gets 15 ms automatically. Report runs: Linux CPU drastically reduced, timing accuracy held on both
  ▎ platforms, Windows CPU unchanged within runner noise — and no longer dependent on syscall-timing side effects.
  ▎
  ▎ Closes #65
  ▎ Closes #66
